### PR TITLE
Add an rewrite rule for handling (getitem, (elemwise, x), i)

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1561,8 +1561,33 @@ def elemwise(op, *args, **kwargs):
                 dtype=dt, name=name)
 
 
+def count_required_args(func):
+    """
+    >>> f = lambda x, y: None
+    >>> g = lambda z=None: None
+    >>> count_required_args(f)
+    2
+    >>> count_required_args(g)
+    0
+    """
+    try:
+        # for numpy.ufunc
+        return func.nin
+    except AttributeError:
+        try:
+            spec = inspect.getargspec(func)
+        except Exception:
+            raise ValueError(
+                'cannot wrap_elemwise without inspectable signature')
+        len_kwargs = len(spec.defaults) if spec.defaults is not None else 0
+        return len(spec.args) - len_kwargs
+
+
 def wrap_elemwise(func, **kwargs):
     """ Wrap up numpy function into dask.array """
+    from .optimization import add_elemwise_getitem_swap_rule
+    nargs = count_required_args(func)
+    add_elemwise_getitem_swap_rule(func, nargs)
     f = partial(elemwise, func, **kwargs)
     f.__doc__ = func.__doc__
     f.__name__ = func.__name__
@@ -1705,9 +1730,7 @@ def modf(x):
 modf.__doc__ = np.modf
 
 
-@wraps(np.around)
-def around(x, decimals=0):
-    return map_blocks(partial(np.around, decimals=decimals), x, dtype=x.dtype)
+around = wrap_elemwise(np.around)
 
 
 def isnull(values):

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -1,3 +1,5 @@
+import operator
+import numpy as np
 import pytest
 pytest.importorskip('numpy')
 
@@ -101,3 +103,32 @@ def test_hard_fuse_slice_cases():
     term = (getarray, (getarray, 'x', (None, slice(None, None))),
                      (slice(None, None), 5))
     assert rewrite_rules.rewrite(term) == (getarray, 'x', (None, 5))
+
+
+def test_swap_getitem_elemwise():
+    pairs = [((getarray, (abs, 'x'), 0),
+              (abs, (getarray, 'x', 0))),
+
+             ((getitem, (abs, 'x'), 0),
+              (abs, (getitem, 'x', 0))),
+
+             ((getitem, (operator.neg, 'x'), 0),
+              (operator.neg, (getitem, 'x', 0))),
+
+             ((getitem, (operator.add, 'x', 'y'), 0),
+              (operator.add, (getitem, 'x', 0), (getitem, 'y', 0))),
+
+             ((getarray, (operator.add, 'x', 'y'), 0),
+              (operator.add, (getarray, 'x', 0), (getarray, 'y', 0))),
+
+             ((getitem, (np.sin, 'x'), 0),
+              (np.sin, (getitem, 'x', 0))),
+
+             ((getitem, (np.logical_or, 'x', 'y'), 0),
+              (np.logical_or, (getitem, 'x', 0), (getitem, 'y', 0))),
+
+        ]
+
+    for inp, expected in pairs:
+        result = rewrite_rules.rewrite(inp)
+        assert result == expected


### PR DESCRIPTION
These should be rewritten from `(getitem, (elemwise, x), i)` to `(elemwise, (getitem, x, i))`. In many cases, this translates into a significant reduction in IO.

This is particularly relevant for computed coordinates, which are ubiquitous in the fields of meteorology and occeanography. These case typically be calculated in a straightforward way from ufuncs, and we would like to support these using dask in xray (see https://github.com/xray/xray/issues/462).

I'll note that this PR is not entirely complete yet -- there are a few other dask array operations that will require wrapping. Also, we would like to optimize the tasks resulting from stacking or concatenation followed by indexing for the same reasons (e.g., so we can apply a coordinate transformation after loading a multi-file dataset).