### PR TITLE
[WIP] - Mixed thread/processes evaluation

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1145,7 +1145,7 @@ def normalize_chunks(chunks, shape=None):
     return tuple(map(tuple, chunks))
 
 
-def from_array(x, chunks, name=None, lock=False):
+def from_array(x, chunks, name=None, lock=False, use_processes=False):
     """ Create dask array from something that looks like an array
 
     Input must have a ``.shape`` and support numpy-style slicing.
@@ -1176,6 +1176,10 @@ def from_array(x, chunks, name=None, lock=False):
         lock = Lock()
     if lock:
         dsk = dict((k, v + (lock,)) for k, v in dsk.items())
+
+    if use_processes:
+        from multiprocessing import run_in_processes
+        dsk = run_in_processes(dsk)
     return Array(merge({name: x}, dsk), name, chunks, dtype=x.dtype)
 
 

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -85,7 +85,8 @@ def run_in_process(func, *args):
     if not _pool[0]:
         _pool[0] = multiprocessing.Pool()
 
-    return pool.apply(func, args)
+    future = dill_apply_async(_pool[0].apply_async, func, args)
+    return future.get()
 
 
 def run_in_processes(dsk):

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from toolz import curry, pipe, partial
 from .optimize import fuse, cull
+from .core import istask
 import multiprocessing
 import dill
 import pickle
@@ -76,3 +77,17 @@ def dill_apply_async(apply_async, func, args=(), kwds={},
     skwds = dumps(kwds)
     return apply_async(curry(apply_func, loads=func_loads),
                        args=[sfunc, sargs, skwds])
+
+
+_pool = [None]
+
+def run_in_process(func, *args):
+    if not _pool[0]:
+        _pool[0] = multiprocessing.Pool()
+
+    return pool.apply(func, args)
+
+
+def run_in_processes(dsk):
+    return dict((k, (run_in_process, v[0]) + v[1:] if istask(v) else v)
+                for k, v in dsk.items())

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -1,7 +1,8 @@
 import pytest
 pytest.importorskip('dill')
 
-from dask.multiprocessing import get, dill_apply_async
+from dask.multiprocessing import (get, dill_apply_async, run_in_process,
+        run_in_processes)
 from dask.context import set_options
 import multiprocessing
 import dill
@@ -67,3 +68,8 @@ def test_dumps_loads():
 def test_fuse_doesnt_clobber_intermediates():
     d = {'x': 1, 'y': (inc, 'x'), 'z': (add, 10, 'y')}
     assert get(d, ['y', 'z']) == (2, 12)
+
+
+def test_run_in_processes():
+    dsk = {'x': 1, 'y': (inc, 'x')}
+    assert run_in_processes(dsk) == {'x': 1, 'y': (run_in_process, inc, 'x')}

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -72,4 +72,8 @@ def test_fuse_doesnt_clobber_intermediates():
 
 def test_run_in_processes():
     dsk = {'x': 1, 'y': (inc, 'x')}
-    assert run_in_processes(dsk) == {'x': 1, 'y': (run_in_process, inc, 'x')}
+    dsk2 = run_in_processes(dsk)
+    assert dsk2 == {'x': 1, 'y': (run_in_process, inc, 'x')}
+
+    from dask.threaded import get as thget
+    assert thget(dsk2, 'y') == get(dsk, 'y')


### PR DESCRIPTION
Fixes #329

This starts an attempt to run tasks in processes even though we use the multiprocessing scheduler.  We wrap tasks in `run_in_process` function which calls out to an external pool.

Some issues:

1.  This doesn't support nested tasks, we may want some form of quoting for this
2.  I suspect that creating the pool may cause issues in windows
3.  This doesn't actually use this functionality anywhere.  Good places to experiment are `Bag.to_dataframe` and `dask.array.from_hdf5`