### PR TITLE
DataFrame/Series.apply

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -941,12 +941,11 @@ class Series(_Frame):
         meth.__doc__ = op.__doc__
         bind_method(cls, name, meth)
 
-    def apply(self, func, convert_dtype=True, columns=no_default, args=(), **kwds):
+    def apply(self, func, convert_dtype=True, name=no_default, args=(), **kwds):
         """ Parallel version of pandas.Series.apply """
-        if columns is no_default:
-            columns = self.name
-
-        return map_partitions(pd.Series.apply, columns, self, func,
+        if name is no_default:
+            name = self.name
+        return map_partitions(pd.Series.apply, name, self, func,
                               convert_dtype, args, **kwds)
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -941,6 +941,22 @@ class Series(_Frame):
         meth.__doc__ = op.__doc__
         bind_method(cls, name, meth)
 
+    def apply(self, func, convert_dtype=True, args=(), **kwds):
+        """ Parallel version of pandas.Series.apply
+
+        This is identical to the Pandas algorithm but assumes that axis=0.
+        The function will be applied per row, not per column.
+
+        The original docstring follows:\n
+        """ + pd.Series.apply.__doc__
+        name = 'apply' + next(tokens)
+        dsk = dict(((name, i),
+                    (apply, pd.Series.apply,
+                      (tuple, [(self._name, i), func, convert_dtype, args]),
+                      kwds))
+                    for i in range(self.npartitions))
+        return Series(merge(self.dask, dsk), name, None, self.divisions)
+
 
 class Index(Series):
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1120,7 +1120,6 @@ class DataFrame(_Frame):
         # *args here is index, columns but columns arg is already used
         return map_partitions(func, column_info, self, None, columns)
 
-
     def query(self, expr, **kwargs):
         """ Blocked version of pd.DataFrame.query
 
@@ -1274,6 +1273,28 @@ class DataFrame(_Frame):
                                   axis=axis, fill_value=fill_value)
         meth.__doc__ = op.__doc__
         bind_method(cls, name, meth)
+
+    def apply(self, func, axis=0, args=(), columns=no_default, **kwds):
+        """ Parallel version of pandas.DataFrame.apply
+
+        This mimics the pandas version except for the following:
+
+        1.  The user must specify axis=0 explicitly
+        2.  The user must provide output columns or column
+        """
+        if axis == 0:
+            raise ValueError("dd.DataFrame.apply only supports axis=1\n"
+                    "  Try: df.apply(func, axis=1)")
+
+        if columns is no_default:
+            raise ValueError(
+            "Please supply column names of output dataframe or series\n"
+            "  Before: df.apply(func)\n"
+            "  After:  df.apply(func, columns=['x', 'y']) for dataframe result\n"
+            "  or:     df.apply(func, columns='x')        for series result")
+
+        return map_partitions(pd.DataFrame.apply, columns, self, func, axis,
+                              False, False, None, args, **kwds)
 
 
 # bind operators

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -949,13 +949,13 @@ class Series(_Frame):
 
         The original docstring follows:\n
         """ + pd.Series.apply.__doc__
-        name = 'apply' + next(tokens)
+        name = 'apply-' + tokenize(self, func, convert_dtype, args, kwds)
         dsk = dict(((name, i),
                     (apply, pd.Series.apply,
                       (tuple, [(self._name, i), func, convert_dtype, args]),
                       kwds))
                     for i in range(self.npartitions))
-        return Series(merge(self.dask, dsk), name, None, self.divisions)
+        return Series(merge(self.dask, dsk), name, self.name, self.divisions)
 
 
 class Index(Series):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -943,8 +943,8 @@ class Series(_Frame):
 
     def apply(self, func, convert_dtype=True, args=(), **kwds):
         """ Parallel version of pandas.Series.apply """
-        return map_partitions(pd.Series.apply, self.name, self, func, convert_dtype, args,
-                **kwds)
+        return map_partitions(pd.Series.apply, self.name, self, func,
+                              convert_dtype, args, **kwds)
 
 
 class Index(Series):
@@ -1272,7 +1272,8 @@ class DataFrame(_Frame):
         2.  The user must provide output columns or column
         """
         if axis == 0:
-            raise ValueError("dd.DataFrame.apply only supports axis=1\n"
+            raise NotImplementedError(
+                    "dd.DataFrame.apply only supports axis=1\n"
                     "  Try: df.apply(func, axis=1)")
 
         if columns is no_default:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -942,20 +942,9 @@ class Series(_Frame):
         bind_method(cls, name, meth)
 
     def apply(self, func, convert_dtype=True, args=(), **kwds):
-        """ Parallel version of pandas.Series.apply
-
-        This is identical to the Pandas algorithm but assumes that axis=0.
-        The function will be applied per row, not per column.
-
-        The original docstring follows:\n
-        """ + pd.Series.apply.__doc__
-        name = 'apply-' + tokenize(self, func, convert_dtype, args, kwds)
-        dsk = dict(((name, i),
-                    (apply, pd.Series.apply,
-                      (tuple, [(self._name, i), func, convert_dtype, args]),
-                      kwds))
-                    for i in range(self.npartitions))
-        return Series(merge(self.dask, dsk), name, self.name, self.divisions)
+        """ Parallel version of pandas.Series.apply """
+        return map_partitions(pd.Series.apply, self.name, self, func, convert_dtype, args,
+                **kwds)
 
 
 class Index(Series):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -941,9 +941,12 @@ class Series(_Frame):
         meth.__doc__ = op.__doc__
         bind_method(cls, name, meth)
 
-    def apply(self, func, convert_dtype=True, args=(), **kwds):
+    def apply(self, func, convert_dtype=True, columns=no_default, args=(), **kwds):
         """ Parallel version of pandas.Series.apply """
-        return map_partitions(pd.Series.apply, self.name, self, func,
+        if columns is no_default:
+            columns = self.name
+
+        return map_partitions(pd.Series.apply, columns, self, func,
                               convert_dtype, args, **kwds)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2020,3 +2020,12 @@ def test_series_groupby():
     assert raises(TypeError, lambda: ss.groupby([1, 2]))
     sss = dd.from_pandas(s, npartitions=3)
     assert raises(NotImplementedError, lambda: ss.groupby(sss))
+
+
+def test_apply():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    a = dd.from_pandas(df, npartitions=2)
+
+
+    func = lambda row: row['x'] + row['y']
+    assert eq(a.x.apply(lambda x: x + 1), df.x.apply(lambda x: x + 1))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2029,3 +2029,9 @@ def test_apply():
 
     func = lambda row: row['x'] + row['y']
     assert eq(a.x.apply(lambda x: x + 1), df.x.apply(lambda x: x + 1))
+
+    assert eq(a.apply(lambda xy: xy[0] + xy[1], axis=1, columns=None),
+              df.apply(lambda xy: xy[0] + xy[1], axis=1))
+
+    assert raises(ValueError, lambda: a.apply(lambda xy: xy, axis=0))
+    assert raises(ValueError, lambda: a.apply(lambda xy: xy, axis=1))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2026,12 +2026,14 @@ def test_apply():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
     a = dd.from_pandas(df, npartitions=2)
 
-
     func = lambda row: row['x'] + row['y']
-    assert eq(a.x.apply(lambda x: x + 1), df.x.apply(lambda x: x + 1))
+    eq(a.x.apply(lambda x: x + 1), df.x.apply(lambda x: x + 1))
 
-    assert eq(a.apply(lambda xy: xy[0] + xy[1], axis=1, columns=None),
-              df.apply(lambda xy: xy[0] + xy[1], axis=1))
+    eq(a.apply(lambda xy: xy[0] + xy[1], axis=1, columns=None),
+       df.apply(lambda xy: xy[0] + xy[1], axis=1))
 
     assert raises(NotImplementedError, lambda: a.apply(lambda xy: xy, axis=0))
     assert raises(ValueError, lambda: a.apply(lambda xy: xy, axis=1))
+
+    func = lambda x: pd.Series([x, x])
+    eq(a.x.apply(func, columns=[0, 1]), df.x.apply(func))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2036,4 +2036,4 @@ def test_apply():
     assert raises(ValueError, lambda: a.apply(lambda xy: xy, axis=1))
 
     func = lambda x: pd.Series([x, x])
-    eq(a.x.apply(func, columns=[0, 1]), df.x.apply(func))
+    eq(a.x.apply(func, name=[0, 1]), df.x.apply(func))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2033,5 +2033,5 @@ def test_apply():
     assert eq(a.apply(lambda xy: xy[0] + xy[1], axis=1, columns=None),
               df.apply(lambda xy: xy[0] + xy[1], axis=1))
 
-    assert raises(ValueError, lambda: a.apply(lambda xy: xy, axis=0))
+    assert raises(NotImplementedError, lambda: a.apply(lambda xy: xy, axis=0))
     assert raises(ValueError, lambda: a.apply(lambda xy: xy, axis=1))


### PR DESCRIPTION
Fixes https://github.com/ContinuumIO/dask/issues/418

I'm currently a bit concerned about `DataFrame.apply` which is not yet implemented.  I think that we need to require `columns=` or `name=` from the users.