### PR TITLE
[WIP] add reanme method to dataframe

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -813,6 +813,17 @@ class DataFrame(_Frame):
 
         return elemwise(_assign, self, *pairs, columns=list(df2.columns))
 
+    @wraps(pd.DataFrame.rename)
+    def rename(self, index=None, columns=None):
+        if index is not None:
+            raise ValueError("Cannot rename index.")
+        column_info = (pd.DataFrame(columns=self.column_info)
+                         .rename(columns=columns).columns)
+        func = pd.DataFrame.rename
+        # *args here is index, columns but columns arg is already used
+        return map_partitions(func, column_info, self, None, columns)
+
+
     def query(self, expr, **kwargs):
         """ Blocked version of pd.DataFrame.query
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1601,3 +1601,21 @@ def test_gh580():
     ddf = dd.from_pandas(df, 2)
     assert eq(np.cos(df['x']), np.cos(ddf['x']))
     assert eq(np.cos(df['x']), np.cos(ddf['x']))
+
+
+def test_rename_dict():
+    renamer = {'a': 'A', 'b': 'B'}
+    assert eq(d.rename(columns=renamer),
+              full.rename(columns=renamer))
+
+
+def test_rename_function():
+    renamer = lambda x: x.upper()
+    assert eq(d.rename(columns=renamer),
+              full.rename(columns=renamer))
+
+
+def test_rename_index():
+    renamer = {0: 1}
+    assert raises(ValueError, lambda: d.rename(index=renamer))
+


### PR DESCRIPTION
I'm not sure if this messes with dasks' token scheme at all.
I also probably need to set `column_info` if that changes, but I have to run for now.

```
In [6]: d.head()
Out[6]:
   a  b
0  1  4
1  2  5
3  3  6

In [7]: d.rename(index=lambda x: x * 10, columns={'a': 'A'}).compute()
Out[7]:
    A  b
0   1  4
10  2  5
30  3  6
50  4  3
60  5  2
80  6  1
90  7  0
90  8  0
90  9  0
```