### PR TITLE
Scheduler resiliency

### DIFF
--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -830,11 +830,8 @@ class Scheduler(object):
         try:
             yield
         except RuntimeError as e:
-            del self.queues[qkey]
-            for w in self.queues_by_worker:
-                self.queues_by_worker[w].pop(qkey, None)
             raise e
-        else:
+        finally:
             del self.queues[qkey]
             for w in self.queues_by_worker:
                 self.queues_by_worker[w].pop(qkey, None)

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -842,6 +842,6 @@ class Scheduler(object):
         except Exception as e:
             raise e
         finally:
-            del self.queues[qkey]
+            self.queues.pop(qkey, None)
             for w in self.queues_by_worker:
                 self.queues_by_worker[w].pop(qkey, None)

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -836,7 +836,7 @@ class Scheduler(object):
     def queue_context(self, qkey):
         try:
             yield
-        except RuntimeError as e:
+        except Exception as e:
             raise e
         finally:
             del self.queues[qkey]

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -374,3 +374,17 @@ def test_schedule_block():
         assert len(s.queues_by_worker[w1.address]) == 0
         assert len(s.queues_by_worker[w2.address]) == 0
         assert len(s.queues) == 0
+
+
+def test_gather_block():
+    with scheduler_and_workers(n=2, scheduler_kwargs={'worker_timeout': 0.1},
+                               worker_kwargs={'heartbeat': 0.01}) as (s, (w1, w2)):
+        s.send_data('x', 1, w1.address)
+        s.send_data('y', 2, w2.address)
+        w2.close()
+        while w2.status != 'closed':
+            sleep(1e-6)
+        assert raises(RuntimeError, lambda: s.gather(['x', 'y']))
+        assert len(s.queues_by_worker[w1.address]) == 0
+        assert len(s.queues_by_worker[w2.address]) == 0
+        assert len(s.queues) == 0

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -357,3 +357,7 @@ def test_scatter_block():
         while w2.status != 'closed':
             sleep(1e-6)
         s.scatter(data)
+        while len(s.queues_by_worker[w1.address]) != 0:
+            sleep(1e-6)
+        assert len(s.queues_by_worker[w1.address]) == 0
+        assert len(s.queues_by_worker[w2.address]) == 0

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -356,7 +356,7 @@ def test_scatter_block():
         w2.close()
         while w2.status != 'closed':
             sleep(1e-6)
-        s.scatter(data)
+        assert raises(RuntimeError, lambda: s.scatter(data))
         while len(s.queues_by_worker[w1.address]) != 0:
             sleep(1e-6)
         assert len(s.queues_by_worker[w1.address]) == 0

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -175,6 +175,7 @@ def test_schedule():
             else:
                 break
         assert not a.data and not b.data
+        assert len(s.queues) == 0
 
 
 def test_gather():
@@ -372,3 +373,4 @@ def test_schedule_block():
         assert raises(RuntimeError, lambda: s.schedule(dsk, ['y']))
         assert len(s.queues_by_worker[w1.address]) == 0
         assert len(s.queues_by_worker[w2.address]) == 0
+        assert len(s.queues) == 0

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -346,3 +346,14 @@ def test_cull_redundant_data():
 
         assert ('x' in a.data and 'x' not in b.data or
                 'x' in b.data and 'x' not in a.data)
+
+
+def test_scatter_block():
+    with scheduler_and_workers(n=2, scheduler_kwargs={'worker_timeout': 0.1},
+                               worker_kwargs={'heartbeat': 0.01}) as (s, (w1, w2)):
+
+        data = {'x': 1, 'y': 2, 'z': 3}
+        w2.close()
+        while w2.status != 'closed':
+            sleep(1e-6)
+        s.scatter(data)

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -370,3 +370,5 @@ def test_schedule_block():
         while w2.status != 'closed':
             sleep(1e-6)
         assert raises(RuntimeError, lambda: s.schedule(dsk, ['y']))
+        assert len(s.queues_by_worker[w1.address]) == 0
+        assert len(s.queues_by_worker[w2.address]) == 0

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -350,7 +350,7 @@ def test_cull_redundant_data():
                 'x' in b.data and 'x' not in a.data)
 
 
-def test_scatter_block():
+def test_scatter_hang():
     with scheduler_and_workers(n=2, scheduler_kwargs={'worker_timeout': 0.1},
                                worker_kwargs={'heartbeat': 0.01}) as (s, (w1, w2)):
 
@@ -363,7 +363,7 @@ def test_scatter_block():
         assert len(s.queues_by_worker[w2.address]) == 0
 
 
-def test_schedule_block():
+def test_schedule_hang():
     with scheduler_and_workers(n=2, scheduler_kwargs={'worker_timeout': 0.1},
                                worker_kwargs={'heartbeat': 0.01}) as (s, (w1, w2)):
         dsk = {'x': (add, 1, 2), 'y': (inc, 'x'), 'z': (add, 'y', 'x')}
@@ -376,7 +376,7 @@ def test_schedule_block():
         assert len(s.queues) == 0
 
 
-def test_gather_block():
+def test_gather_hang():
     with scheduler_and_workers(n=2, scheduler_kwargs={'worker_timeout': 0.1},
                                worker_kwargs={'heartbeat': 0.01}) as (s, (w1, w2)):
         s.send_data('x', 1, w1.address)


### PR DESCRIPTION
This makes the scheduler methods `gather`, `scatter`, and `schedule` resilient to worker failure.