### PR TITLE
Quote operation

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -417,3 +417,28 @@ def isdag(d, keys):
     getcycle
     """
     return not getcycle(d, keys)
+
+
+def list2(L):
+    return list(L)
+
+
+def quote(x):
+    """ Ensure that this value remains this value in a dask graph
+
+    Some values in dask graph take on special meaning.  Lists become iterators,
+    tasks get executed.  Sometimes we want to ensure that our data is not
+    interpreted but remains literal.
+
+    >>> quote([1, 2, 3])
+    (<function list2 at ...>, [1, 2, 3])
+
+    >>> from operator import add
+    >>> quote((add, 1, 2))  # doctest: +SKIP
+    (tuple, [add, 1, 2])
+    """
+    if isinstance(x, list):
+        return (list2, x)
+    if istask(x):
+        return (tuple, list(x))
+    return x

--- a/dask/core.py
+++ b/dask/core.py
@@ -438,7 +438,7 @@ def quote(x):
     (tuple, [add, 1, 2])
     """
     if isinstance(x, list):
-        return (list2, x)
+        return (list2, list(map(quote, x)))
     if istask(x):
-        return (tuple, list(x))
+        return (tuple, list(map(quote, x)))
     return x

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,8 +1,9 @@
 from collections import namedtuple
+from operator import add
 
 from dask.utils import raises
 from dask.core import (istask, get, get_dependencies, flatten, subs,
-                       preorder_traversal)
+                       preorder_traversal, quote, list2)
 
 
 def contains(a, b):
@@ -160,3 +161,8 @@ def test_subs_with_surprisingly_friendly_eq():
     else:
         df = pd.DataFrame()
         assert subs(df, 'x', 1) is df
+
+
+def test_quote():
+    assert quote([1, 2, 3]) == (list2, [1, 2, 3])
+    assert quote((add, 1, 2)) == (tuple, [add, 1, 2])

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -164,5 +164,8 @@ def test_subs_with_surprisingly_friendly_eq():
 
 
 def test_quote():
-    assert quote([1, 2, 3]) == (list2, [1, 2, 3])
-    assert quote((add, 1, 2)) == (tuple, [add, 1, 2])
+    literals = [[1, 2, 3], (add, 1, 2),
+                [1, [2, 3]], (add, 1, (add, 2, 3))]
+
+    for l in literals:
+        assert get({'x': quote(l)}, 'x') == l


### PR DESCRIPTION
This provides a `quote` function to core that ensures values are interpreted as written.

```python
>>> quote((add, 1, 2))  # doctest: +SKIP
(tuple, [add, 1, 2])
```
