### PR TITLE
Add DataFrame.merge and DataFrame.join

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -990,6 +990,20 @@ class DataFrame(_Frame):
                          .columns)
         return elemwise(pd.DataFrame.drop, self, labels, axis, columns=columns)
 
+    @wraps(pd.DataFrame.merge)
+    def merge(self, right, how='inner', on=None, left_on=None, right_on=None,
+              left_index=False, right_index=False,
+              suffixes=('_x', '_y'), npartitions=None):
+
+        if not isinstance(right, (DataFrame, pd.DataFrame)):
+            raise ValueError('right must be DataFrame')
+
+        from .multi import merge
+        return merge(self, right, how=how, on=on,
+                     left_on=left_on, right_on=right_on,
+                     left_index=left_index, right_index=right_index,
+                     suffixes=suffixes, npartitions=npartitions)
+
 
 def _assign(df, *pairs):
     kwargs = dict(partition(2, pairs))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1004,6 +1004,19 @@ class DataFrame(_Frame):
                      left_index=left_index, right_index=right_index,
                      suffixes=suffixes, npartitions=npartitions)
 
+    @wraps(pd.DataFrame.join)
+    def join(self, other, on=None, how='left',
+             lsuffix='', rsuffix='', npartitions=None):
+
+        if not isinstance(other, (DataFrame, pd.DataFrame)):
+            raise ValueError('other must be DataFrame')
+
+        from .multi import merge
+        return merge(self, other, how=how,
+                     left_index=on is None, right_index=True,
+                     left_on=on, suffixes=[lsuffix, rsuffix],
+                     npartitions=npartitions)
+
 
 def _assign(df, *pairs):
     kwargs = dict(partition(2, pairs))

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -197,17 +197,11 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
 def pdmerge(left, right, how, left_on, right_on,
             left_index, right_index, suffixes,
             default_left_columns, default_right_columns):
-    # print(left)
-    # print(right)
+
     if not len(left):
-        # print(left.columns.tolist())
-        # print(default_left_columns)
-        # assert left.columns.tolist() == default_left_columns
         left = pd.DataFrame([], columns=default_left_columns)
+
     if not len(right):
-        # print(right.columns.tolist())
-        # print(default_right_columns)
-        # assert right.columns.tolist() == default_right_columns
         right = pd.DataFrame([], columns=default_right_columns)
 
     result = pd.merge(left, right, how=how,
@@ -218,7 +212,7 @@ def pdmerge(left, right, how, left_on, right_on,
 
 
 def hash_join(lhs, left_on, rhs, right_on, how='inner',
-              npartitions=None, suffixes=('_x', '_y'), join=False):
+              npartitions=None, suffixes=('_x', '_y')):
     """ Join two DataFrames on particular columns with hash join
 
     This shuffles both datasets on the joined column and then performs an
@@ -337,8 +331,6 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
                                        lsuffix=suffixes[0], rsuffix=suffixes[1])
 
     else:                           # Do hash join
-
-        # DataFrame.join can have different column order from merge
         return hash_join(left, left.index if left_index else left_on,
                          right, right.index if right_index else right_on,
                          how, npartitions, suffixes)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -147,7 +147,6 @@ def _set_collect(group, p, barrier_token, columns):
         return p.get(group)
     except ValueError:
         assert columns is not None, columns
-        print(columns)
         # when unable to get group, create dummy DataFrame
         # which has the same columns as original
         return pd.DataFrame([], columns=columns)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -110,11 +110,12 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     name = 'set-partition--collect-' + token
     if compute and not categories:
         dsk4.update(dict(((name, i),
-                     (_set_collect, i, p, barrier_token))
+                     (_set_collect, i, p, barrier_token, df.columns))
                      for i in range(len(divisions) - 1)))
     else:
         dsk4.update(dict(((name, i),
-                     (_categorize, catname2, (_set_collect, i, p, barrier_token)))
+                     (_categorize, catname2,
+                        (_set_collect, i, p, barrier_token, df.columns)))
                     for i in range(len(divisions) - 1)))
 
     dsk = merge(df.dask, dsk1, dsk2, dsk3, dsk4)
@@ -140,12 +141,16 @@ def _set_partition(df, index, divisions, p):
     p.append(dict(enumerate(shards)))
 
 
-def _set_collect(group, p, barrier_token):
+def _set_collect(group, p, barrier_token, columns):
     """ Get new partition dataframe from partd """
     try:
         return p.get(group)
     except ValueError:
-        return pd.DataFrame()
+        assert columns is not None, columns
+        print(columns)
+        # when unable to get group, create dummy DataFrame
+        # which has the same columns as original
+        return pd.DataFrame([], columns=columns)
 
 
 def shuffle(df, index, npartitions=None):

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -246,16 +246,12 @@ def test_merge_by_index_patterns():
                           'd': [7, 6, 5, 4, 3, 2, 1]},
                           index=list('abcdefg'))
 
-    pdf3l = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
-                          'b': [7, 6, 5, 4, 3, 2, 1]},
-                          index=list('abcdefg'))
+    pdf3l = pdf2l
     pdf3r = pd.DataFrame({'c': [6, 7, 8, 9],
                           'd': [5, 4, 3, 2]},
                           index=list('abdg'))
 
-    pdf4l = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
-                          'b': [7, 6, 5, 4, 3, 2, 1]},
-                          index=list('abcdefg'))
+    pdf4l = pdf2l
     pdf4r = pd.DataFrame({'c': [9, 10, 11, 12],
                           'd': [5, 4, 3, 2]},
                           index=list('abdg'))
@@ -282,7 +278,6 @@ def test_merge_by_index_patterns():
                           'd': [5, 4, 3, 2]},
                           index=list('fghi'))
 
-
     for pdl, pdr in [(pdf1l, pdf1r), (pdf2l, pdf2r), (pdf3l, pdf3r),
                      (pdf4l, pdf4r), (pdf5l, pdf5r), (pdf6l, pdf6r),
                      (pdf7l, pdf7r)]:
@@ -306,22 +301,105 @@ def test_merge_by_index_patterns():
                    pdl.merge(pdr, how=how, left_index=True, right_index=True))
 
                 # hash join
-                list_eq(dd.merge(ddl, ddr, how=how, left_index='a', right_index='c'),
-                        pd.merge(pdl, pdr, how=how, left_index='a', right_index='c'))
-                list_eq(dd.merge(ddl, ddr, how=how, left_index='b', right_index='d'),
-                        pd.merge(pdl, pdr, how=how, left_index='b', right_index='d'))
+                list_eq(dd.merge(ddl, ddr, how=how, left_on='a', right_on='c'),
+                        pd.merge(pdl, pdr, how=how, left_on='a', right_on='c'))
+                list_eq(dd.merge(ddl, ddr, how=how, left_on='b', right_on='d'),
+                        pd.merge(pdl, pdr, how=how, left_on='b', right_on='d'))
 
-                list_eq(dd.merge(ddr, ddl, how=how, left_index='a', right_index='c'),
-                        pd.merge(pdr, pdl, how=how, left_index='a', right_index='c'))
-                list_eq(dd.merge(ddr, ddl, how=how, left_index='b', right_index='d'),
-                        pd.merge(pdr, pdl, how=how, left_index='b', right_index='d'))
+                list_eq(dd.merge(ddr, ddl, how=how, left_on='c', right_on='a'),
+                        pd.merge(pdr, pdl, how=how, left_on='c', right_on='a'))
+                list_eq(dd.merge(ddr, ddl, how=how, left_on='d', right_on='b'),
+                        pd.merge(pdr, pdl, how=how, left_on='d', right_on='b'))
 
                 list_eq(ddl.merge(ddr, how=how, left_on='a', right_on='c'),
                         pdl.merge(pdr, how=how, left_on='a', right_on='c'))
-                list_eq(ddl.merge(ddr, how=how, left_index='b', right_index='d'),
-                        pdl.merge(pdr, how=how, left_index='b', right_index='d'))
+                list_eq(ddl.merge(ddr, how=how, left_on='b', right_on='d'),
+                        pdl.merge(pdr, how=how, left_on='b', right_on='d'))
 
-                list_eq(ddr.merge(ddl, how=how, left_index='a', right_index='c'),
-                        pdr.merge(pdl, how=how, left_index='a', right_index='c'))
-                list_eq(ddr.merge(ddl, how=how, left_index='b', right_index='d'),
-                        pdr.merge(pdl, how=how, left_index='b', right_index='d'))
+                list_eq(ddr.merge(ddl, how=how, left_on='c', right_on='a'),
+                        pdr.merge(pdl, how=how, left_on='c', right_on='a'))
+                list_eq(ddr.merge(ddl, how=how, left_on='d', right_on='b'),
+                        pdr.merge(pdl, how=how, left_on='d', right_on='b'))
+
+def test_join_by_index_patterns():
+
+    # Similar test cases as test_merge_by_index_patterns,
+    # but columns / index for join have same dtype
+
+    pdf1l = pd.DataFrame({'a': list('abcdefg'),
+                          'b': [7, 6, 5, 4, 3, 2, 1]},
+                         index=list('abcdefg'))
+    pdf1r = pd.DataFrame({'c': list('abcdefg'),
+                          'd': [7, 6, 5, 4, 3, 2, 1]},
+                         index=list('abcdefg'))
+
+    pdf2l = pdf1l
+    pdf2r = pd.DataFrame({'c': list('gfedcba'),
+                          'd': [7, 6, 5, 4, 3, 2, 1]},
+                          index=list('abcdefg'))
+
+    pdf3l = pdf1l
+    pdf3r = pd.DataFrame({'c': list('abdg'),
+                          'd': [5, 4, 3, 2]},
+                          index=list('abdg'))
+
+    pdf4l = pd.DataFrame({'a': list('abcabce'),
+                          'b': [7, 6, 5, 4, 3, 2, 1]},
+                          index=list('abcdefg'))
+    pdf4r = pd.DataFrame({'c': list('abda'),
+                          'd': [5, 4, 3, 2]},
+                          index=list('abdg'))
+
+    # completely different index
+    pdf5l = pd.DataFrame({'a': list('lmnopqr'),
+                          'b': [7, 6, 5, 4, 3, 2, 1]},
+                          index=list('lmnopqr'))
+    pdf5r = pd.DataFrame({'c': list('abcd'),
+                          'd': [5, 4, 3, 2]},
+                          index=list('abcd'))
+
+    pdf6l = pd.DataFrame({'a': list('cdefghi'),
+                          'b': [7, 6, 5, 4, 3, 2, 1]},
+                          index=list('cdefghi'))
+    pdf6r = pd.DataFrame({'c': list('abab'),
+                          'd': [5, 4, 3, 2]},
+                          index=list('abcd'))
+
+    pdf7l = pd.DataFrame({'a': list('aabbccd'),
+                          'b': [7, 6, 5, 4, 3, 2, 1]},
+                          index=list('abcdefg'))
+    pdf7r = pd.DataFrame({'c': list('ABCD'),
+                          'd': [5, 4, 3, 2]},
+                          index=list('fghi'))
+
+    for pdl, pdr in [(pdf1l, pdf1r), (pdf2l, pdf2r), (pdf3l, pdf3r),
+                     (pdf4l, pdf4r), (pdf5l, pdf5r), (pdf6l, pdf6r),
+                     (pdf7l, pdf7r)]:
+        for lpart, rpart in [(2, 2), (3, 2), (2, 3)]:
+
+            ddl = dd.from_pandas(pdl, lpart)
+            ddr = dd.from_pandas(pdr, rpart)
+
+            for how in ['inner', 'outer', 'left', 'right']:
+                eq(ddl.join(ddr, how=how), pdl.join(pdr, how=how))
+                eq(ddr.join(ddl, how=how), pdr.join(pdl, how=how))
+
+                eq(ddl.join(ddr, how=how, lsuffix='l', rsuffix='r'),
+                   pdl.join(pdr, how=how, lsuffix='l', rsuffix='r'))
+                eq(ddr.join(ddl, how=how, lsuffix='l', rsuffix='r'),
+                   pdr.join(pdl, how=how, lsuffix='l', rsuffix='r'))
+
+                list_eq(ddl.join(ddr, how=how, on='a', lsuffix='l', rsuffix='r'),
+                        pdl.join(pdr, how=how, on='a', lsuffix='l', rsuffix='r'))
+                list_eq(ddr.join(ddl, how=how, on='c', lsuffix='l', rsuffix='r'),
+                        pdr.join(pdl, how=how, on='c', lsuffix='l', rsuffix='r'))
+
+                # merge with index and columns
+                list_eq(ddl.merge(ddr, how=how, left_on='a', right_index=True),
+                        pdl.merge(pdr, how=how, left_on='a', right_index=True))
+                list_eq(ddr.merge(ddl, how=how, left_on='c', right_index=True),
+                        pdr.merge(pdl, how=how, left_on='c', right_index=True))
+                list_eq(ddl.merge(ddr, how=how, left_index=True, right_on='c'),
+                        pdl.merge(pdr, how=how, left_index=True, right_on='c'))
+                list_eq(ddr.merge(ddl, how=how, left_index=True, right_on='a'),
+                        pdr.merge(pdl, how=how, left_index=True, right_on='a'))


### PR DESCRIPTION
Add following methods which exists in ``pandas``. 

- ``DataFrame.merge``: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.merge.html
- ``DataFrame.join``: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.join.html

Also, fixed a bug ``dd.merge`` when column name is specified like ``left_on='x'`` and ``right_index=True``.

```
A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': [1, 1, 2, 2, 3, 4]})
a = dd.repartition(A, [0, 4, 5])

B = pd.DataFrame({'y': [1, 3, 4, 4, 5, 6], 'z': [6, 5, 4, 3, 2, 1]})
b = dd.repartition(B, [0, 2, 5])

dd.merge(a, b, left_on='x', right_index=True).compute()
# stalls...
```

dd.merge(a, b, left_on='x', right_index=True).compute()

### ToDo:

Currently, ``DataFrame.join`` using ``on`` kw doesn't work as expected. I'm digging in further. 