### PR TITLE
Added support for 'encoding' in bag

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -890,10 +890,10 @@ def write(data, filename, encoding):
     ext = os.path.splitext(filename)[1][1:]
     if ext == 'gz':
         f = gzip.open(filename, 'wb')
-        data = (line.encode(encoding=encoding) for line in data)
+        data = (line.encode(encoding) for line in data)
     elif ext == 'bz2':
         f = bz2.BZ2File(filename, 'wb')
-        data = (line.encode(encoding=encoding) for line in data)
+        data = (line.encode(encoding) for line in data)
     else:
         f = open(filename, 'w')
     try:

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -821,6 +821,10 @@ def collect(grouper, group, p, barrier_token):
     return list(d.items())
 
 
+def decode_sequence(encoding, seq):
+    for item in seq:
+        yield item.decode(encoding)
+
 opens = {'gz': gzip.open, 'bz2': bz2.BZ2File}
 
 
@@ -862,7 +866,7 @@ def from_filenames(filenames, chunkbytes=None, encoding=system_encoding):
         extension = os.path.splitext(filenames[0])[1].strip('.')
         myopen = opens.get(extension, open)
 
-        d = dict(((name, i), (list, (myopen, fn)))
+        d = dict(((name, i), (list, (decode_sequence, encoding, (myopen, fn))))
                  for i, fn in enumerate(full_filenames))
 
     return Bag(d, name, len(d))

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -866,7 +866,7 @@ def from_filenames(filenames, chunkbytes=None, encoding=system_encoding):
         extension = os.path.splitext(filenames[0])[1].strip('.')
         myopen = opens.get(extension, open)
 
-        d = dict(((name, i), (list, (decode_sequence, encoding, (myopen, fn))))
+        d = dict(((name, i), (list, (decode_sequence, encoding, (myopen, fn, 'rb'))))
                  for i, fn in enumerate(full_filenames))
 
     return Bag(d, name, len(d))

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -8,6 +8,7 @@ import gzip
 import zlib
 import bz2
 import os
+import codecs
 
 from fnmatch import fnmatchcase
 from glob import glob
@@ -343,8 +344,8 @@ class Bag(Base):
                              "Use db.from_filenames instead.")
 
     @wraps(to_textfiles)
-    def to_textfiles(self, path, name_function=str):
-        return to_textfiles(self, path, name_function)
+    def to_textfiles(self, path, name_function=str, encoding=system_encoding):
+        return to_textfiles(self, path, name_function, encoding)
 
     def fold(self, binop, combine=None, initial=no_default):
         """ Parallelizable reduction
@@ -895,7 +896,7 @@ def write(data, filename, encoding):
         f = bz2.BZ2File(filename, 'wb')
         data = (line.encode(encoding) for line in data)
     else:
-        f = open(filename, 'w')
+        f = codecs.open(filename, 'wb', encoding=encoding)
     try:
         for item in data:
             f.write(item)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -37,6 +37,8 @@ names = ('bag-%d' % i for i in itertools.count(1))
 tokens = ('-%d' % i for i in itertools.count(1))
 load_names = ('load-%d' % i for i in itertools.count(1))
 
+system_encoding = getdefaultencoding()
+
 no_default = '__no__default__'
 
 
@@ -105,7 +107,7 @@ def list2(seq):
     return list(seq)
 
 
-def to_textfiles(b, path, name_function=str):
+def to_textfiles(b, path, name_function=str, encoding=system_encoding):
     """ Write bag to disk, one filename per partition, one line per element
 
     **Paths**: This will create one file for each partition in your bag. You
@@ -167,7 +169,7 @@ def to_textfiles(b, path, name_function=str):
                 "3.  A path with a * in it -- 'foo.*.json'")
 
     name = next(names)
-    dsk = dict(((name, i), (write, (b.name, i), path))
+    dsk = dict(((name, i), (write, (b.name, i), path, encoding))
             for i, path in enumerate(paths))
 
     return Bag(merge(b.dask, dsk), name, b.npartitions)
@@ -822,7 +824,7 @@ def collect(grouper, group, p, barrier_token):
 opens = {'gz': gzip.open, 'bz2': bz2.BZ2File}
 
 
-def from_filenames(filenames, chunkbytes=None, encoding=getdefaultencoding()):
+def from_filenames(filenames, chunkbytes=None, encoding=system_encoding):
     """ Create dask by loading in lines from many files
 
     Provide list of filenames
@@ -870,12 +872,12 @@ def _chunk_read_file(filename, chunkbytes, encoding):
     extension = os.path.splitext(filename)[1].strip('.')
     compression = {'gz': 'gzip', 'bz2': 'bz2'}.get(extension, None)
 
-    return [(list, (StringIO, (bytes.decode(encoding),
-                    (textblock, filename, i, i + chunkbytes, compression))))
+    return [(list, (StringIO, (bytes.decode,
+                    (textblock, filename, i, i + chunkbytes, compression), encoding)))
              for i in range(0, file_size(filename, compression), chunkbytes)]
 
 
-def write(data, filename):
+def write(data, filename, encoding):
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):
         with ignoring(OSError):
@@ -884,10 +886,10 @@ def write(data, filename):
     ext = os.path.splitext(filename)[1][1:]
     if ext == 'gz':
         f = gzip.open(filename, 'wb')
-        data = (line.encode() for line in data)
+        data = (line.encode(encoding=encoding) for line in data)
     elif ext == 'bz2':
         f = bz2.BZ2File(filename, 'wb')
-        data = (line.encode() for line in data)
+        data = (line.encode(encoding=encoding) for line in data)
     else:
         f = open(filename, 'w')
     try:

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -821,7 +821,7 @@ def collect(grouper, group, p, barrier_token):
 opens = {'gz': gzip.open, 'bz2': bz2.BZ2File}
 
 
-def from_filenames(filenames, chunkbytes=None):
+def from_filenames(filenames, chunkbytes=None, encoding='utf-8'):
     """ Create dask by loading in lines from many files
 
     Provide list of filenames
@@ -852,7 +852,7 @@ def from_filenames(filenames, chunkbytes=None):
 
     if chunkbytes:
         chunkbytes = int(chunkbytes)
-        taskss = [_chunk_read_file(fn, chunkbytes) for fn in full_filenames]
+        taskss = [_chunk_read_file(fn, chunkbytes, encoding) for fn in full_filenames]
         d = dict(((name, i), task)
                  for i, task in enumerate(toolz.concat(taskss)))
     else:
@@ -865,11 +865,11 @@ def from_filenames(filenames, chunkbytes=None):
     return Bag(d, name, len(d))
 
 
-def _chunk_read_file(filename, chunkbytes):
+def _chunk_read_file(filename, chunkbytes, encoding):
     extension = os.path.splitext(filename)[1].strip('.')
     compression = {'gz': 'gzip', 'bz2': 'bz2'}.get(extension, None)
 
-    return [(list, (StringIO, (bytes.decode,
+    return [(list, (StringIO, (bytes.decode(encoding),
                     (textblock, filename, i, i + chunkbytes, compression))))
              for i in range(0, file_size(filename, compression), chunkbytes)]
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -14,6 +14,7 @@ from glob import glob
 from collections import Iterable, Iterator, defaultdict
 from functools import wraps, partial
 from dask.utils import takes_multiple_arguments
+from sys import getdefaultencoding
 
 
 from toolz import (merge, frequencies, merge_with, take, reduce,
@@ -821,7 +822,7 @@ def collect(grouper, group, p, barrier_token):
 opens = {'gz': gzip.open, 'bz2': bz2.BZ2File}
 
 
-def from_filenames(filenames, chunkbytes=None, encoding='utf-8'):
+def from_filenames(filenames, chunkbytes=None, encoding=getdefaultencoding()):
     """ Create dask by loading in lines from many files
 
     Provide list of filenames

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function
+from sys import getdefaultencoding
 
 import pytest
 pytest.importorskip('dill')
@@ -22,6 +23,8 @@ import partd
 from tempfile import mkdtemp
 
 from collections import Iterator
+
+system_encoding = getdefaultencoding()
 
 dsk = {('x', 0): (range, 5),
        ('x', 1): (range, 5),
@@ -304,16 +307,16 @@ def test_from_filenames_gzip():
     b = db.from_filenames(['foo.json.gz', 'bar.json.gz'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, 'ascii', (gzip.open, os.path.abspath('foo.json.gz')))),
-                 (list, (decode_sequence, 'ascii', (gzip.open, os.path.abspath('bar.json.gz'))))]))
+            set([(list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('foo.json.gz')))),
+                 (list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('bar.json.gz'))))]))
 
 
 def test_from_filenames_bz2():
     b = db.from_filenames(['foo.json.bz2', 'bar.json.bz2'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, 'ascii', (bz2.BZ2File, os.path.abspath('foo.json.bz2')))),
-                 (list, (decode_sequence, 'ascii', (bz2.BZ2File, os.path.abspath('bar.json.bz2'))))]))
+            set([(list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('foo.json.bz2')))),
+                 (list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('bar.json.bz2'))))]))
 
 
 def test_from_filenames_large():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -307,16 +307,16 @@ def test_from_filenames_gzip():
     b = db.from_filenames(['foo.json.gz', 'bar.json.gz'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('foo.json.gz')))),
-                 (list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('bar.json.gz'))))]))
+            set([(list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('foo.json.gz'), 'rb'))),
+                 (list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('bar.json.gz'), 'rb')))]))
 
 
 def test_from_filenames_bz2():
     b = db.from_filenames(['foo.json.bz2', 'bar.json.bz2'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('foo.json.bz2')))),
-                 (list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('bar.json.bz2'))))]))
+            set([(list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('foo.json.bz2'), 'rb'))),
+                 (list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('bar.json.bz2'), 'rb')))]))
 
 
 def test_from_filenames_large():
@@ -354,7 +354,7 @@ def test_from_filenames_large_gzip():
         b = db.from_filenames(fn, chunkbytes=100)
         c = db.from_filenames(fn)
         assert len(b.dask) > 5
-        assert list(b) == [s.decode() for s in c]
+        assert list(b) == list(c)
 
 
 @pytest.mark.slow

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function
 
 import pytest
@@ -325,6 +326,19 @@ def test_from_filenames_large():
         assert list(map(str, b)) == list(map(str, c))
 
         d = db.from_filenames([fn], chunkbytes=100)
+        assert list(b) == list(d)
+
+
+def test_from_filenames_encoding():
+    with tmpfile() as fn:
+        with open(fn, 'wb') as f:
+            f.write((u'你好！' + os.linesep).encode('gb18030') * 100)
+        b = db.from_filenames(fn, chunkbytes=100, encoding='gb18030')
+        c = db.from_filenames(fn, encoding='gb18030')
+        assert len(b.dask) > 5
+        assert list(map(str, b)) == list(map(str, c))
+
+        d = db.from_filenames([fn], chunkbytes=100, encoding='gb18030')
         assert list(b) == list(d)
 
 


### PR DESCRIPTION
When using dask bag to process some text data, I noticed that using UTF-8 encoded input files made the library crash with the ubiquitous `UnicodeDecodeError` since `bytes.decode()` was using the default _ascii_ codec in the `_chunk_read_file` method.

I thus added the possibility to pass 'encoding' as a parameter to the function, solving the issue. I set default value as 'utf-8' but I could modify if there is a better suggestion.