### PR TITLE
Allow dd.concat to handle known divisions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1459,53 +1459,108 @@ def reduction(x, chunk, aggregate, token=None):
     return Scalar(merge(x.dask, dsk, dsk2), b)
 
 
-def concat(dfs):
-    """ Concatenate dataframes along rows
+def _concat_dfs(dfs, name):
+    """ Internal function to concat dask dict and DataFrame.columns """
+    dsk = dict()
+    i = 0
+    for df in dfs:
+        for key in df._keys():
+            dsk[(name, i)] = key
+            i += 1
 
-    - If divisions are known, concatenate every divisions each by each.
-    - If divisions are unknown, concatenate to the last
-    - Concatenating DataFrames mixed with known and unknown divisions are not
-      supported.
+    empties = [pd.DataFrame(columns=df.columns) for df in dfs]
+    columns = pd.concat(empties, axis=0, join='outer').columns
+
+    return dsk, columns
+
+
+def concat(dfs, interleave_partitions=False):
+    """ Concatenate DataFrames along rows.
+
+    - If all divisions are known and ordered, concatenate DataFrames keeping
+      divisions. When divisions are not ordered, specifying
+      interleave_partition=True allows concatenate divisions each by each.
+    - If any of division is unknown, concatenate DataFrames resetting its
+      division to unknown (None)
+
+    Parameters
+    ----------
+
+    dfs: list
+        List of dask.DataFrames to be concatenated
+    interleave_partitions: bool, default False
+        Whether to concatenate DataFrames ignoring its order. If True, every
+        divisions are concatenated each by each.
+
+    Examples
+    --------
+
+    # If all divisions are known and ordered, divisions are kept.
+    >>> a                                               # doctest: +SKIP
+    dd.DataFrame<x, divisions=(1, 3, 5)>
+    >>> b                                               # doctest: +SKIP
+    dd.DataFrame<y, divisions=(6, 8, 10)>
+    >>> dd.concat([a, b])                               # doctest: +SKIP
+    dd.DataFrame<concat-..., divisions=(1, 3, 6, 8, 10)>
+
+    # Unable to concatenate if divisions are not ordered.
+    >>> a                                               # doctest: +SKIP
+    dd.DataFrame<x, divisions=(1, 3, 5)>
+    >>> b                                               # doctest: +SKIP
+    dd.DataFrame<y, divisions=(2, 3, 6)>
+    >>> dd.concat([a, b])                               # doctest: +SKIP
+    ValueError: All inputs have known divisions which cannnot be concatenated
+    in order. Specify interleave_partitions=True to ignore order
+
+    # Specify interleave_partitions=True to ignore the division order.
+    >>> dd.concat([a, b], interleave_partitions=True)   # doctest: +SKIP
+    dd.DataFrame<concat-..., divisions=(1, 2, 3, 5, 6)>
+
+    # If any of division is unknown, the result division will be unknown
+    >>> a                                               # doctest: +SKIP
+    dd.DataFrame<x, divisions=(None, None)>
+    >>> b                                               # doctest: +SKIP
+    dd.DataFrame<y, divisions=(1, 4, 10)>
+    >>> dd.concat([a, b])                               # doctest: +SKIP
+    dd.DataFrame<concat-..., divisions=(None, None, None, None)>
     """
     if not isinstance(dfs, list):
         dfs = [dfs]
     if len(dfs) == 0:
-        raise ValueError('Input must be a list')
+        raise ValueError('Input must be a list longer than 0')
 
     if all(df.known_divisions for df in dfs):
-        from .multi import _maybe_align_partitions
-        dfs = _maybe_align_partitions(dfs)
+        # each DataFrame's division must be greater than previous one
+        if all(dfs[i].divisions[-1] < dfs[i + 1].divisions[0]
+               for i in range(len(dfs) - 1)):
+            name = 'concat-{0}'.format(tokenize(*dfs))
+            dsk, columns = _concat_dfs(dfs, name)
+
+            divisions = []
+            for df in dfs[:-1]:
+                # remove last to concatenate with next
+                divisions += df.divisions[:-1]
+            divisions += dfs[-1].divisions
+
+            return DataFrame(merge(dsk, *[df.dask for df in dfs]), name,
+                             columns, divisions)
+        else:
+            if interleave_partitions:
+                from .multi import concat_indexed_dataframes
+                return concat_indexed_dataframes(dfs)
+
+            raise ValueError('All inputs have known divisions which cannnot be '
+                             'concatenated in order. Specify '
+                             'interleave_partitions=True to ignore order')
+
+    else:
         name = 'concat-{0}'.format(tokenize(*dfs))
+        dsk, columns = _concat_dfs(dfs, name)
 
-        dsk = dict()
-        for i in range(dfs[0].npartitions):
-            dsk[(name, i)] = (_concat, (list, [(df._name, i) for df in dfs]))
-
-        dasks = [df.dask for df in dfs]
-
-        empties = [pd.DataFrame([], columns=df.columns) for df in dfs]
-        columns = pd.concat(empties).columns.tolist()
-
-        return DataFrame(merge(dsk, *dasks), name,
-                         columns, dfs[0].divisions)
-
-    elif all(not df.known_divisions for df in dfs):
-        name = 'concat-{0}'.format(tokenize(*dfs))
-        dsk = dict()
-        i = 0
-        for df in dfs:
-            for key in df._keys():
-                dsk[(name, i)] = key
-                i += 1
-
-        divisions = [None] * (i + 1)
+        divisions = [None] * (len(dsk) + 1)
 
         return DataFrame(merge(dsk, *[df.dask for df in dfs]), name,
-                         dfs[0].columns, divisions)
-    else:
-        msg = ("concat can't handle dataframes mixed "
-               "with known and unknown divisions")
-        raise NotImplementedError(msg)
+                         columns, divisions)
 
 
 def _groupby_apply(df, ind, func):

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -194,8 +194,8 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
     (lhs, rhs), divisions, parts = align_partitions(lhs, rhs)
     divisions, parts = require(divisions, parts, required[how])
 
-    left_empty = pd.DataFrame([], columns=lhs.columns)
-    right_empty = pd.DataFrame([], columns=rhs.columns)
+    left_empty = pd.DataFrame(columns=lhs.columns)
+    right_empty = pd.DataFrame(columns=rhs.columns)
 
     name = 'join-indexed-' + tokenize(lhs, rhs, how, lsuffix, rsuffix)
     dsk = dict(((name, i),
@@ -219,10 +219,10 @@ def pdmerge(left, right, how, left_on, right_on,
             default_left_columns, default_right_columns):
 
     if not len(left):
-        left = pd.DataFrame([], columns=default_left_columns)
+        left = pd.DataFrame(columns=default_left_columns)
 
     if not len(right):
-        right = pd.DataFrame([], columns=default_right_columns)
+        right = pd.DataFrame(columns=default_right_columns)
 
     result = pd.merge(left, right, how=how,
                       left_on=left_on, right_on=right_on,
@@ -259,8 +259,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
         right_index = False
 
     # fake column names
-    left_empty = pd.DataFrame([], columns=lhs.columns)
-    right_empty = pd.DataFrame([], columns=rhs.columns)
+    left_empty = pd.DataFrame(columns=lhs.columns)
+    right_empty = pd.DataFrame(columns=rhs.columns)
     j = pd.merge(left_empty, right_empty, how, None,
                  left_on=left_on, right_on=right_on,
                  left_index=left_index, right_index=right_index,
@@ -292,12 +292,12 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
 
 def concat_indexed_dataframes(dfs, join='outer'):
     """ Concatenate indexed dataframes together along the index """
-    assert join in ('inner', 'outer')
+    if join not in ('inner', 'outer'):
+        raise ValueError("'join' must be 'inner' or 'outer'")
     dfs2, divisions, parts = align_partitions(*dfs)
 
-    empties = [pd.DataFrame([], columns=df.columns) for df in dfs]
-
-    columns = pd.concat(empties, 0, join).columns
+    empties = [pd.DataFrame(columns=df.columns) for df in dfs]
+    columns = pd.concat(empties, axis=0, join=join).columns
 
     parts2 = [[df if df is not None else empty
                for df, empty in zip(part, empties)]

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -123,7 +123,6 @@ def align_partitions(*dfs):
 
 def _maybe_align_partitions(args):
     """ Align DataFrame blocks if divisions are different """
-
     # passed to align_partitions
     indexer, dasks = zip(*[x for x in enumerate(args)
                            if isinstance(x[1], (_Frame, Scalar))])


### PR DESCRIPTION
Allow ``dask.dataframe.concat`` to concat ``DataFrame`` with known divisions. In this case, not concatenated to last, but concatenate every divisions each by each.

Another option is concatenate to last resetting all divisions to ``None``, but I think it is not very useful.

```
import pandas as pd
import dask.dataframe as dd
df1 = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [1, 2 ,3 ,4]})
df2 = pd.DataFrame({'a': [5, 6, 7, 8], 'b': [5, 6 ,7 ,8]})
ddf1 = dd.from_pandas(df1, 2)
ddf2 = dd.from_pandas(df2, 2)

ddf1.divisions
# (0, 2, 3)

dd.concat([ddf1, ddf2]).compute()
#    a  b
# 0  1  1
# 1  2  2
# 0  5  5
# 1  6  6
# 2  3  3
# 3  4  4
# 2  7  7
# 3  8  8
```