### PR TITLE
Add dataframe.core.Scalar arithmetic

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import operator
 import sys
+import types
 
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
@@ -21,10 +23,11 @@ if PY3:
         else:
             return func(*args)
     range = range
+    operator_div = operator.truediv
+
 else:
     import __builtin__ as builtins
     from Queue import Queue, Empty
-    import operator
     from itertools import izip_longest as zip_longest
     from StringIO import StringIO
     from io import BytesIO
@@ -35,7 +38,31 @@ else:
     long = long
     apply = apply
     range = xrange
-
+    operator_div = operator.div
 
 def skip(func):
     return
+
+
+def bind_method(cls, name, func):
+    """Bind a method to class
+
+    Parameters
+    ----------
+
+    cls : type
+        class to receive bound method
+    name : basestring
+        name of method on class instance
+    func : function
+        function to be bound as method
+
+    Returns
+    -------
+    None
+    """
+    # only python 2 has bound/unbound method issue
+    if not PY3:
+        setattr(cls, name, types.MethodType(func, None, cls))
+    else:
+        setattr(cls, name, func)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -616,6 +616,126 @@ def check_frame_arithmetics(l, r, el, er, allow_comparison_ops=True):
         assert eq(~(l == r), ~(el == er))
 
 
+def test_scalar_arithmetics():
+    l = dd.core.Scalar({('l', 0): 10}, 'l')
+    r = dd.core.Scalar({('r', 0): 4}, 'r')
+    el = 10
+    er = 4
+
+    assert isinstance(l, dd.core.Scalar)
+    assert isinstance(r, dd.core.Scalar)
+
+    # l, r may be repartitioned, test whether repartition keeps original data
+    assert eq(l, el)
+    assert eq(r, er)
+
+    assert eq(l + r, el + er)
+    assert eq(l * r, el * er)
+    assert eq(l - r, el - er)
+    assert eq(l / r, el / er)
+    assert eq(l // r, el // er)
+    assert eq(l ** r, el ** er)
+    assert eq(l % r, el % er)
+
+    assert eq(l & r, el & er)
+    assert eq(l | r, el | er)
+    assert eq(l ^ r, el ^ er)
+    assert eq(l > r, el > er)
+    assert eq(l < r, el < er)
+    assert eq(l >= r, el >= er)
+    assert eq(l <= r, el <= er)
+    assert eq(l == r, el == er)
+    assert eq(l != r, el != er)
+
+    assert eq(l + 2, el + 2)
+    assert eq(l * 2, el * 2)
+    assert eq(l - 2, el - 2)
+    assert eq(l / 2, el / 2)
+    assert eq(l & True, el & True)
+    assert eq(l | True, el | True)
+    assert eq(l ^ True, el ^ True)
+    assert eq(l // 2, el // 2)
+    assert eq(l ** 2, el ** 2)
+    assert eq(l % 2, el % 2)
+    assert eq(l > 2, el > 2)
+    assert eq(l < 2, el < 2)
+    assert eq(l >= 2, el >= 2)
+    assert eq(l <= 2, el <= 2)
+    assert eq(l == 2, el == 2)
+    assert eq(l != 2, el != 2)
+
+    assert eq(2 + r, 2 + er)
+    assert eq(2 * r, 2 * er)
+    assert eq(2 - r, 2 - er)
+    assert eq(2 / r, 2 / er)
+    assert eq(True & r, True & er)
+    assert eq(True | r, True | er)
+    assert eq(True ^ r, True ^ er)
+    assert eq(2 // r, 2 // er)
+    assert eq(2 ** r, 2 ** er)
+    assert eq(2 % r, 2 % er)
+    assert eq(2 > r, 2 > er)
+    assert eq(2 < r, 2 < er)
+    assert eq(2 >= r, 2 >= er)
+    assert eq(2 <= r, 2 <= er)
+    assert eq(2 == r, 2 == er)
+    assert eq(2 != r, 2 != er)
+
+    assert eq(-l, -el)
+    assert eq(abs(l), abs(el))
+
+    assert eq(~(l == r), ~(el == er))
+
+
+def test_scalar_arithmetics_with_dask_instances():
+    s = dd.core.Scalar({('s', 0): 10}, 's')
+    e = 10
+
+    pds = pd.Series([1, 2, 3, 4, 5, 6, 7])
+    dds = dd.from_pandas(pds, 2)
+
+    pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
+                        'b': [7, 6, 5, 4, 3, 2, 1]})
+    ddf = dd.from_pandas(pdf, 2)
+
+    # pandas Series
+    result = pds + s   # this result pd.Series (automatically computed)
+    assert isinstance(result, pd.Series)
+    assert eq(result, pds + e)
+
+    result = s + pds   # this result dd.Series
+    assert isinstance(result, dd.Series)
+    assert eq(result, pds + e)
+
+    # dask Series
+    result = dds + s   # this result dd.Series
+    assert isinstance(result, dd.Series)
+    assert eq(result, pds + e)
+
+    result = s + dds   # this result dd.Series
+    assert isinstance(result, dd.Series)
+    assert eq(result, pds + e)
+
+
+    # pandas DataFrame
+    result = pdf + s   # this result pd.DataFrame (automatically computed)
+    assert isinstance(result, pd.DataFrame)
+    assert eq(result, pdf + e)
+
+    result = s + pdf   # this result dd.DataFrame
+    assert isinstance(result, dd.DataFrame)
+    assert eq(result, pdf + e)
+
+    # dask DataFrame
+    result = ddf + s   # this result dd.DataFrame
+    assert isinstance(result, dd.DataFrame)
+    assert eq(result, pdf + e)
+
+    result = s + ddf   # this result dd.DataFrame
+    assert isinstance(result, dd.DataFrame)
+    assert eq(result, pdf + e)
+
+
 def test_reductions():
     nans1 = pd.Series([1] + [np.nan] * 4 + [2] + [np.nan] * 3)
     nands1 = dd.from_pandas(nans1, 2)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -18,17 +18,36 @@ def test_align_partitions():
                      index=[30, 70, 80, 100])
     b = dd.repartition(B, [30, 80, 100])
 
+    s = dd.core.Scalar({('s', 0): 10}, 's')
+
     (aa, bb), divisions, L = align_partitions(a, b)
-    assert isinstance(a, dd.DataFrame)
-    assert isinstance(b, dd.DataFrame)
-    assert divisions == (10, 30, 40, 60, 80, 100)
-    assert isinstance(L, list)
-    assert len(divisions) == 1 + len(L)
+
+    def _check(a, b, aa, bb):
+        assert isinstance(a, dd.DataFrame)
+        assert isinstance(b, dd.DataFrame)
+        assert isinstance(aa, dd.DataFrame)
+        assert isinstance(bb, dd.DataFrame)
+        assert eq(a, aa)
+        assert eq(b, bb)
+        assert divisions == (10, 30, 40, 60, 80, 100)
+        assert isinstance(L, list)
+        assert len(divisions) == 1 + len(L)
+
+    _check(a, b, aa, bb)
     assert L == [[(aa._name, 0), (bb._name, 0)],
                  [(aa._name, 1), (bb._name, 1)],
                  [(aa._name, 2), (bb._name, 2)],
                  [(aa._name, 3), (bb._name, 3)],
                  [(aa._name, 4), (bb._name, 4)]]
+
+    (aa, ss, bb), divisions, L = align_partitions(a, s, b)
+    _check(a, b, aa, bb)
+    assert L == [[(aa._name, 0), None, (bb._name, 0)],
+                 [(aa._name, 1), None, (bb._name, 1)],
+                 [(aa._name, 2), None, (bb._name, 2)],
+                 [(aa._name, 3), None, (bb._name, 3)],
+                 [(aa._name, 4), None, (bb._name, 4)]]
+    assert eq(ss, 10)
 
     ldf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
                         'b': [7, 6, 5, 4, 3, 2, 1]})


### PR DESCRIPTION
Currently, ``Scalar`` ops raise an error.

```
import pandas as pd
import dask.dataframe as dd

s = dd.core.Scalar({('s', 0): 10}, 's')
s + s
# TypeError: unsupported operand type(s) for +: 'Scalar' and 'Scalar'
```

This PR defines ``Scalar`` ops, including ``Scalar`` and ``Series/DataFrame``. Also refactored unary/binary ops definitions. I think the same refactoring can be applied to ``Array`` in separate PR.

#### After the PR

```
s + s
# <dask.dataframe.core.Scalar object at 0x105563b50>

pds = pd.Series([1, 2, 3, 4, 5, 6, 7])
dds = dd.from_pandas(pds, 2)

# this results in ``pd.Series`` because ``pd.Series`` is on lhs
pds + s
# 0    11
# 1    12
# 2    13
# 3    14
# 4    15
# 5    16
# 6    17
# dtype: int64

s + pds
# dd.Series<add-62ef541579ba7516d9eca4b9df9f5c6d, divisions=(0, 6)>

dds + s
# dd.Series<elemwise-0b7f20c43f24ee60e37bcb33df8cd214, divisions=(0, 4, 6)>

s + dds
# dd.Series<elemwise-5655d3d333719cf68bd46ee1626b13fc, divisions=(0, 4, 6)>
```