### PR TITLE
Enforce names in map_partitions

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1741,3 +1741,16 @@ def test_to_frame():
 
     assert eq(s.to_frame(), a.to_frame())
     assert eq(s.to_frame('bar'), a.to_frame('bar'))
+
+
+def test_series_groupby_propagates_names():
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
+    ddf = dd.from_pandas(df, 2)
+    func = lambda df: df['y'].sum()
+
+    result = ddf.groupby('x').apply(func, columns='y')
+
+    expected = df.groupby('x').apply(func)
+    expected.name = 'y'
+
+    tm.assert_series_equal(result.compute(), expected)


### PR DESCRIPTION
This ensures that the names of the partitions match the column names
given in ``map_partitions`` calls

Fixes #620
Fixes #627