### PR TITLE
Add Dataframe cumulative methods

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -907,6 +907,25 @@ def test_reductions_frame_dtypes():
     assert eq(df.var(ddof=0), ddf.var(ddof=0))
     assert eq(df.mean(), ddf.mean())
 
+def test_cumulative():
+    pdf = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))
+    ddf = dd.from_pandas(pdf, 5)
+
+    assert eq(ddf.cumsum(), pdf.cumsum())
+    assert eq(ddf.cumprod(), pdf.cumprod())
+    assert eq(ddf.cummin(), pdf.cummin())
+    assert eq(ddf.cummax(), pdf.cummax())
+
+    assert eq(ddf.cumsum(axis=1), pdf.cumsum(axis=1))
+    assert eq(ddf.cumprod(axis=1), pdf.cumprod(axis=1))
+    assert eq(ddf.cummin(axis=1), pdf.cummin(axis=1))
+    assert eq(ddf.cummax(axis=1), pdf.cummax(axis=1))
+
+    assert eq(ddf.a.cumsum(), pdf.a.cumsum())
+    assert eq(ddf.a.cumprod(), pdf.a.cumprod())
+    assert eq(ddf.a.cummin(), pdf.a.cummin())
+    assert eq(ddf.a.cummax(), pdf.a.cummax())
+
 def test_dropna():
     df = pd.DataFrame({'x': [np.nan, 2,      3, 4, np.nan,      6],
                        'y': [1,      2, np.nan, 4, np.nan, np.nan],


### PR DESCRIPTION
Add cumulatives supported by ``pandas``. ``cumsum``, ``cumprod``, ``cummax`` and  ``cummin``.

```
import numpy as np
import pandas as pd
import dask.dataframe as dd
df = pd.DataFrame(np.random.randn(100, 5), columns=list('abcde'))
ddf = dd.from_pandas(df, 5)

df.cumsum().tail()
#            a         b         c         d         e
# 95  4.254821  1.090218 -6.759547 -0.639530  0.841811
# 96  3.815062  0.794742 -6.650667  0.427233  1.843134
# 97  2.872289  1.181701 -5.607922  1.319124  0.566535
# 98  4.101066  0.562392 -6.794201  0.978797  0.731615
# 99  4.262819 -0.796577 -6.876801  1.034554 -1.821897

ddf.cumsum().compute().tail()
#            a         b         c         d         e
# 95  4.254821  1.090218 -6.759547 -0.639530  0.841811
# 96  3.815062  0.794742 -6.650667  0.427233  1.843134
# 97  2.872289  1.181701 -5.607922  1.319124  0.566535
# 98  4.101066  0.562392 -6.794201  0.978797  0.731615
# 99  4.262819 -0.796577 -6.876801  1.034554 -1.821897
```