### PR TITLE
BUG: DataFrame ops with dask and pandas may be incorrect

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -55,7 +55,7 @@ We proceed with hash joins in the following stages:
 """
 
 from ..base import tokenize
-from .core import repartition, _Frame, DataFrame, Index
+from .core import repartition, _Frame, Scalar, DataFrame, Index
 from .io import from_pandas
 from .shuffle import shuffle
 from bisect import bisect_left, bisect_right
@@ -119,6 +119,19 @@ def align_partitions(*dfs):
                 L.append(None)
         result.append(L)
     return dfs2, tuple(divisions), result
+
+
+def _maybe_align_partitions(dasks):
+    """ Align DataFrame blocks if divisions are different """
+    dasks = [df for df in dasks if isinstance(df, (_Frame, Scalar))]
+    dfs = [df for df in dasks if isinstance(df, _Frame)]
+    if not isinstance(dfs, list) or len(dfs) == 0:
+        raise ValueError('Input must be a list longer than 0')
+
+    divisions = dfs[0].divisions
+    if not all(df.divisions == divisions for df in dfs):
+        dasks, _, _ = align_partitions(*dasks)
+    return dasks
 
 
 def require(divisions, parts, required=None):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -340,7 +340,9 @@ def test_arithmetics():
              (d, ddf4, full, pdf4),
              (d, ddf4.repartition([0, 9]), full, pdf4),
              (d.repartition([0, 3, 9]), ddf4.repartition([0, 5, 9]),
-              full, pdf4)]
+              full, pdf4),
+             # dask + pandas
+             (d, pdf4, full, pdf4), (ddf2, pdf3, pdf2, pdf3)]
 
     for (l, r, el, er) in cases:
         check_series_arithmetics(l.a, r.b, el.a, er.b)
@@ -376,7 +378,9 @@ def test_arithmetics():
              (ddf7.repartition(['a', 'c', 'h']), ddf8.repartition(['a', 'h']),
               pdf7, pdf8),
              (ddf7.repartition(['a', 'b', 'e', 'h']),
-              ddf8.repartition(['a', 'e', 'h']), pdf7, pdf8)]
+              ddf8.repartition(['a', 'e', 'h']), pdf7, pdf8),
+             # dask + pandas
+             (ddf5, pdf6, pdf5, pdf6), (ddf7, pdf8, pdf7, pdf8)]
 
     for (l, r, el, er) in cases:
         check_series_arithmetics(l.a, r.b, el.a, er.b,
@@ -427,7 +431,11 @@ def test_arithmetics_different_index():
              (ddf5.repartition([1, 7, 8, 9]), ddf6.repartition([2, 3, 4, 6]),
               pdf5, pdf6),
              (ddf6.repartition([2, 6]), ddf5.repartition([1, 3, 7, 9]),
-              pdf6, pdf5)]
+              pdf6, pdf5),
+             # dask + pandas
+             (ddf1, pdf2, pdf1, pdf2), (ddf2, pdf1, pdf2, pdf1),
+             (ddf3, pdf4, pdf3, pdf4), (ddf4, pdf3, pdf4, pdf3),
+             (ddf5, pdf6, pdf5, pdf6), (ddf6, pdf5, pdf6, pdf5)]
 
     for (l, r, el, er) in cases:
         check_series_arithmetics(l.a, r.b, el.a, er.b,
@@ -465,8 +473,10 @@ def test_arithmetics_different_index():
              (ddf8.repartition([-5, 0, 10, 20], force=True),
               ddf7.repartition([-1, 4, 11, 13], force=True), pdf8, pdf7),
              (ddf9, ddf10, pdf9, pdf10),
-             (ddf10, ddf9, pdf10, pdf9)
-             ]
+             (ddf10, ddf9, pdf10, pdf9),
+             # dask + pandas
+             (ddf7, pdf8, pdf7, pdf8), (ddf8, pdf7, pdf8, pdf7),
+             (ddf9, pdf10, pdf9, pdf10), (ddf10, pdf9, pdf10, pdf9)]
 
     for (l, r, el, er) in cases:
         check_series_arithmetics(l.a, r.b, el.a, er.b,
@@ -477,7 +487,7 @@ def test_arithmetics_different_index():
 
 def check_series_arithmetics(l, r, el, er, allow_comparison_ops=True):
     assert isinstance(l, dd.Series)
-    assert isinstance(r, dd.Series)
+    assert isinstance(r, (dd.Series, pd.Series))
     assert isinstance(el, pd.Series)
     assert isinstance(er, pd.Series)
 
@@ -549,7 +559,7 @@ def check_series_arithmetics(l, r, el, er, allow_comparison_ops=True):
 
 def check_frame_arithmetics(l, r, el, er, allow_comparison_ops=True):
     assert isinstance(l, dd.DataFrame)
-    assert isinstance(r, dd.DataFrame)
+    assert isinstance(r, (dd.DataFrame, pd.DataFrame))
     assert isinstance(el, pd.DataFrame)
     assert isinstance(er, pd.DataFrame)
     # l, r may be repartitioned, test whether repartition keeps original data


### PR DESCRIPTION
Found a following bug.

```
import numpy as np
import dask.dataframe as dd
import pandas as pd

df1 = pd.DataFrame({'a': [1, 2, 3 ,np.nan], 'b': [1, 1, np.nan, 2]})
df2 = pd.DataFrame({'a': [1, 2, 3 , 4], 'b': [1, 1, 1, 2]})

ddf1 = dd.from_pandas(df1, 2)

# NG: dask + pandas
(ddf1 + df2).compute()
#     a   b
# 0   2   2
# 1   4   2
# 2 NaN NaN
# 3 NaN NaN
# 0 NaN NaN
# 1 NaN NaN
# 2   6 NaN
# 3 NaN   4

# Expected: pandas + pandas
df1 + df2
#     a   b
# 0   2   2
# 1   4   2
# 2   6 NaN
# 3 NaN   4
```