### PR TITLE
Add dataframe flexible arithmetic methods

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -748,6 +748,104 @@ def test_scalar_arithmetics_with_dask_instances():
     assert eq(result, pdf + e)
 
 
+def test_frame_series_arithmetic_methods():
+
+    pdf1 = pd.DataFrame({'A': np.arange(10),
+                         'B': [np.nan, 1, 2, 3, 4] * 2,
+                         'C': [np.nan] * 10,
+                         'D': np.arange(10)},
+                        index=list('abcdefghij'), columns=list('ABCD'))
+    pdf2 = pd.DataFrame(np.random.randn(10, 4),
+                        index=list('abcdefghjk'), columns=list('ABCX'))
+    ps1 = pdf1.A
+    ps2 = pdf2.A
+
+    ddf1 = dd.from_pandas(pdf1, 2)
+    ddf2 = dd.from_pandas(pdf2, 2)
+    ds1 = ddf1.A
+    ds2 = ddf2.A
+
+    s = dd.core.Scalar({('s', 0): 4}, 's')
+
+    for l, r, el, er in [(ddf1, ddf2, pdf1, pdf2), (ds1, ds2, ps1, ps2),
+                         (ddf1.repartition(['a', 'f', 'j']), ddf2, pdf1, pdf2),
+                         (ds1.repartition(['a', 'b', 'f', 'j']), ds2, ps1, ps2),
+                         (ddf1, ddf2.repartition(['a', 'k']), pdf1, pdf2),
+                         (ds1, ds2.repartition(['a', 'b', 'd', 'h', 'k']), ps1, ps2),
+                         (ddf1, 3, pdf1, 3), (ds1, 3, ps1, 3),
+                         (ddf1, s, pdf1, 4), (ds1, s, ps1, 4)]:
+        # l, r may be repartitioned, test whether repartition keeps original data
+        assert eq(l, el)
+        assert eq(r, er)
+
+        assert eq(l.add(r, fill_value=0), el.add(er, fill_value=0))
+        assert eq(l.sub(r, fill_value=0), el.sub(er, fill_value=0))
+        assert eq(l.mul(r, fill_value=0), el.mul(er, fill_value=0))
+        assert eq(l.div(r, fill_value=0), el.div(er, fill_value=0))
+        assert eq(l.truediv(r, fill_value=0), el.truediv(er, fill_value=0))
+        assert eq(l.floordiv(r, fill_value=1), el.floordiv(er, fill_value=1))
+        assert eq(l.mod(r, fill_value=0), el.mod(er, fill_value=0))
+        assert eq(l.pow(r, fill_value=0), el.pow(er, fill_value=0))
+
+        assert eq(l.radd(r, fill_value=0), el.radd(er, fill_value=0))
+        assert eq(l.rsub(r, fill_value=0), el.rsub(er, fill_value=0))
+        assert eq(l.rmul(r, fill_value=0), el.rmul(er, fill_value=0))
+        assert eq(l.rdiv(r, fill_value=0), el.rdiv(er, fill_value=0))
+        assert eq(l.rtruediv(r, fill_value=0), el.rtruediv(er, fill_value=0))
+        assert eq(l.rfloordiv(r, fill_value=1), el.rfloordiv(er, fill_value=1))
+        assert eq(l.rmod(r, fill_value=0), el.rmod(er, fill_value=0))
+        assert eq(l.rpow(r, fill_value=0), el.rpow(er, fill_value=0))
+
+    for l, r, el, er in [(ddf1, ds2, pdf1, ps2), (ddf1, ddf2.X, pdf1, pdf2.X)]:
+        assert eq(l, el)
+        assert eq(r, er)
+
+        # must specify axis=0 to add Series to each column
+        # axis=1 is not supported (add to each row)
+        assert eq(l.add(r, axis=0), el.add(er, axis=0))
+        assert eq(l.sub(r, axis=0), el.sub(er, axis=0))
+        assert eq(l.mul(r, axis=0), el.mul(er, axis=0))
+        assert eq(l.div(r, axis=0), el.div(er, axis=0))
+        assert eq(l.truediv(r, axis=0), el.truediv(er, axis=0))
+        assert eq(l.floordiv(r, axis=0), el.floordiv(er, axis=0))
+        assert eq(l.mod(r, axis=0), el.mod(er, axis=0))
+        assert eq(l.pow(r, axis=0), el.pow(er, axis=0))
+
+        assert eq(l.radd(r, axis=0), el.radd(er, axis=0))
+        assert eq(l.rsub(r, axis=0), el.rsub(er, axis=0))
+        assert eq(l.rmul(r, axis=0), el.rmul(er, axis=0))
+        assert eq(l.rdiv(r, axis=0), el.rdiv(er, axis=0))
+        assert eq(l.rtruediv(r, axis=0), el.rtruediv(er, axis=0))
+        assert eq(l.rfloordiv(r, axis=0), el.rfloordiv(er, axis=0))
+        assert eq(l.rmod(r, axis=0), el.rmod(er, axis=0))
+        assert eq(l.rpow(r, axis=0), el.rpow(er, axis=0))
+
+        assert raises(ValueError, lambda: l.add(r, axis=1))
+
+    for l, r, el, er in [(ddf1, pdf2, pdf1, pdf2), (ddf1, ps2, pdf1, ps2)]:
+        assert eq(l, el)
+        assert eq(r, er)
+
+        for axis in [0, 1, 'index', 'columns']:
+            assert eq(l.add(r, axis=axis), el.add(er, axis=axis))
+            assert eq(l.sub(r, axis=axis), el.sub(er, axis=axis))
+            assert eq(l.mul(r, axis=axis), el.mul(er, axis=axis))
+            assert eq(l.div(r, axis=axis), el.div(er, axis=axis))
+            assert eq(l.truediv(r, axis=axis), el.truediv(er, axis=axis))
+            assert eq(l.floordiv(r, axis=axis), el.floordiv(er, axis=axis))
+            assert eq(l.mod(r, axis=axis), el.mod(er, axis=axis))
+            assert eq(l.pow(r, axis=axis), el.pow(er, axis=axis))
+
+            assert eq(l.radd(r, axis=axis), el.radd(er, axis=axis))
+            assert eq(l.rsub(r, axis=axis), el.rsub(er, axis=axis))
+            assert eq(l.rmul(r, axis=axis), el.rmul(er, axis=axis))
+            assert eq(l.rdiv(r, axis=axis), el.rdiv(er, axis=axis))
+            assert eq(l.rtruediv(r, axis=axis), el.rtruediv(er, axis=axis))
+            assert eq(l.rfloordiv(r, axis=axis), el.rfloordiv(er, axis=axis))
+            assert eq(l.rmod(r, axis=axis), el.rmod(er, axis=axis))
+            assert eq(l.rpow(r, axis=axis), el.rpow(er, axis=axis))
+
+
 def test_reductions():
     nans1 = pd.Series([1] + [np.nan] * 4 + [2] + [np.nan] * 3)
     nands1 = dd.from_pandas(nans1, 2)
@@ -965,7 +1063,7 @@ def test_map_partitions_multi_argument():
 def test_map_partitions():
     assert eq(d.map_partitions(lambda df: df, columns=d.columns), full)
     assert eq(d.map_partitions(lambda df: df), full)
-    result = d.map_partitions(lambda df: df.sum(axis=1), None)
+    result = d.map_partitions(lambda df: df.sum(axis=1), columns=None)
     assert eq(result, full.sum(axis=1))
 
 


### PR DESCRIPTION
``pandas`` has a flexible operation methods allows filling holes and specifying operation axis.

```
import numpy as np
import dask.dataframe as dd
import pandas as pd

df1 = pd.DataFrame({0: [1, 2, 3 ,np.nan], 1: [1, 1, np.nan, 2]})
df2 = pd.DataFrame({0: [1, 2, 3 , 4], 1: [1, 1, 1, 2]})

ddf1 = dd.from_pandas(df1, 2)

ddf1.add(df2).compute()
#     0   1
# 0   2   2
# 1   4   2
# 2   6 NaN
# 3 NaN   4

ddf1.add(df2, fill_value=0).compute()
#    0  1
# 0  2  2
# 1  4  2
# 2  6  1
# 3  4  4

# add Series to each row
ddf1.add(df2[0]).compute()
#     0   1   2   3
# 0   2   3 NaN NaN
# 1   3   3 NaN NaN
# 2 NaN NaN NaN NaN
# 3 NaN NaN NaN NaN

# add Series to each column
ddf1.add(df2[0], axis=0).compute()
#     0   1
# 0   2   2
# 1   4   3
# 2   6 NaN
# 3 NaN   6
```

