### PR TITLE
Close #551, raise a nice error message when read_csv guesses column dtype incorrectly.

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -141,7 +141,7 @@ def read_csv(fn, *args, **kwargs):
         nchunks = int(ceil(total_bytes / chunkbytes))
         divisions = [None] * (nchunks + 1)
 
-        first_read_csv = partial(pd.read_csv, *args, header=header,
+        first_read_csv = partial(try_pd_read_csv, *args, header=header,
                                **dissoc(kwargs, 'compression'))
         rest_read_csv = partial(pd.read_csv, *args, header=None,
                               **dissoc(kwargs, 'compression'))

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -38,17 +38,17 @@ def try_pd_read_csv(*args, **kwargs):
 
     try:
         return pd.read_csv(*args, **kwargs)
-    except ValueError as e:
+    except ValueError as pandas_exception:
         try:
             # this is brittle
-            e_parts = e.message.split(' ')
-            column_number = int(e_parts[-1])
+            parts = pandas_exception.message.split(' ')
+            column_number = int(parts[-1])
             column_name = kwargs.get('names')[column_number]
-            dtype1 = e_parts[7]
-            dtype2 = e_parts[9]
+            dtype1 = parts[7]
+            dtype2 = parts[9]
             msg %= (column_name, dtype1, dtype2, column_name, dtype2)
-        except:
-            raise e
+        except Exception as _:
+            raise pandas_exception
         raise ValueError(msg)
 
 

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -39,13 +39,16 @@ def try_pd_read_csv(*args, **kwargs):
     try:
         return pd.read_csv(*args, **kwargs)
     except ValueError as e:
-        # this is brittle
-        e_parts = e.message.split(' ')
-        column_number = int(e_parts[-1])
-        column_name = kwargs.get('names')[column_number]
-        dtype1 = e_parts[7]
-        dtype2 = e_parts[9]
-        msg %= (column_name, dtype1, dtype2, column_name, dtype2)
+        try:
+            # this is brittle
+            e_parts = e.message.split(' ')
+            column_number = int(e_parts[-1])
+            column_name = kwargs.get('names')[column_number]
+            dtype1 = e_parts[7]
+            dtype2 = e_parts[9]
+            msg %= (column_name, dtype1, dtype2, column_name, dtype2)
+        except:
+            raise e
         raise ValueError(msg)
 
 

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -145,9 +145,9 @@ def read_csv(fn, *args, **kwargs):
         divisions = [None] * (nchunks + 1)
 
         first_read_csv = partial(try_pd_read_csv, *args, header=header,
-                               **dissoc(kwargs, 'compression'))
-        rest_read_csv = partial(pd.read_csv, *args, header=None,
-                              **dissoc(kwargs, 'compression'))
+                                 **dissoc(kwargs, 'compression'))
+        rest_read_csv = partial(try_pd_read_csv, *args, header=None,
+                                **dissoc(kwargs, 'compression'))
 
         # Create dask graph
         dsk = dict(((name, i), (rest_read_csv, (BytesIO,

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -41,7 +41,7 @@ def try_pd_read_csv(*args, **kwargs):
     except ValueError as pandas_exception:
         try:
             # this is brittle
-            parts = pandas_exception.message.split(' ')
+            parts = str(pandas_exception).split(' ')
             column_number = int(parts[-1])
             column_name = kwargs.get('names')[column_number]
             dtype1 = parts[7]

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -648,5 +648,8 @@ def test_bad_csv():
             file_.write('1,foo\n')
         file_.write('1.5,bar\n')
         file_.seek(0)
-        a = dd.read_csv(file_.name)
-        pytest.raises(ValueError, lambda: a.compute())
+        try:
+            dd.read_csv(file_.name).compute()
+            raise ValueError
+        except ValueError as e:
+            assert "dtype={'numbers': float64}" in e.message

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -639,3 +639,14 @@ def test_to_bag():
     assert ddf.to_bag(True).compute(get=get_sync) == list(a.itertuples(True))
     assert ddf.x.to_bag(True).compute(get=get_sync) == list(a.x.iteritems())
     assert ddf.x.to_bag().compute(get=get_sync) == list(a.x)
+
+
+def test_bad_csv():
+    with tempfile.NamedTemporaryFile() as file_:
+        file_.write('numbers,names\n')
+        for i in range(1000):
+            file_.write('1,foo\n')
+        file_.write('1.5,bar\n')
+        file_.seek(0)
+        a = dd.read_csv(file_.name)
+        pytest.raises(ValueError, lambda: a.compute())

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -642,14 +642,13 @@ def test_to_bag():
 
 
 def test_bad_csv():
-    with tempfile.NamedTemporaryFile() as file_:
-        file_.write('numbers,names\n')
-        for i in range(1000):
-            file_.write('1,foo\n')
-        file_.write('1.5,bar\n')
-        file_.seek(0)
+    text = 'numbers,names\n'
+    for i in range(1000):
+        text += '1,foo\n'
+    text += '1.5,bar\n'
+    with filetext(text) as fn:
         try:
-            dd.read_csv(file_.name).compute()
+            dd.read_csv(fn).compute()
             raise ValueError
         except ValueError as e:
-            assert "dtype={'numbers': float64}" in e.message
+            assert "dtype={'numbers': float64}" in str(e)


### PR DESCRIPTION
Closes #551 
```python
In [1]: import tempfile

In [2]: import dask.dataframe as dd

In [3]: with tempfile.NamedTemporaryFile() as f:
    f.write('numbers,names\n')
    for i in range(10000):
        f.write('1,foo\n')
    f.write('1.5,bar\n')
    f.seek(0)
    a = dd.read_csv(f.name)
    a.compute()
   ...:
 ---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-d9a65ae0259b> in <module>()
      6     f.seek(0)
      7     a = dd.read_csv(f.name)
----> 8     a.compute()
      9 

/home/blake/github/dask/dask/base.pyc in compute(self, **kwargs)
     27 
     28     def compute(self, **kwargs):
---> 29         return compute(self, **kwargs)[0]
     30 
     31     @classmethod

/home/blake/github/dask/dask/base.pyc in compute(*args, **kwargs)
     95                 for opt, val in groups.items()])
     96     keys = [arg._keys() for arg in args]
---> 97     results = get(dsk, keys, **kwargs)
     98     return tuple(a._finalize(a, r) for a, r in zip(args, results))
     99 

/home/blake/github/dask/dask/threaded.pyc in get(dsk, result, cache, num_workers, **kwargs)
     55     results = get_async(pool.apply_async, len(pool._pool), dsk, result,
     56                         cache=cache, queue=queue, get_id=_thread_get_id,
---> 57                         **kwargs)
     58 
     59     return results

/home/blake/github/dask/dask/async.pyc in get_async(apply_async, num_workers, dsk, result, cache, queue, get_id, raise_on_exception, rerun_exceptions_locally, callbacks, **kwargs)
    498                 "    dataset.compute(rerun_exceptions_locally=True)\n\n"
    499                 "The original exception and traceback follow below:\n\n"
--> 500                     + str(res) + "\n\nTraceback:\n" + tb)
    501         state['cache'][key] = res
    502         finish_task(dsk, key, state, results, keyorder.get)

ValueError: Exception occurred in remote worker.

Something you've asked dask to compute raised an exception.
That exception and the traceback are copied below.
To use pdb, rerun the computation with the keyword argument
    dask.set_options(rerun_exceptions_locally=True)
    or
    dataset.compute(rerun_exceptions_locally=True)

The original exception and traceback follow below:


    By inspecting the first 1,000 rows of your csv file we guessed that the
    column: numbers had dtype: <i8. But now that we're reading all the data we see it
    has some values with dtype: float64. You should probably add the following
    keyword arguments to your `read_csv` call:

        dtype={'numbers': float64}
    

Traceback:
  File "/home/blake/github/dask/dask/async.py", line 266, in execute_task
    result = _execute_task(task, data)
  File "/home/blake/github/dask/dask/async.py", line 249, in _execute_task
    return func(*args2)
  File "/home/blake/github/dask/dask/dataframe/io.py", line 49, in try_pd_read_csv
    raise ValueError(msg)
```