### PR TITLE
use np.bincount call to determine dtype of da.bincount

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2111,12 +2111,12 @@ def bincount(x, weights=None, minlength=None):
         dsk = dict(((name, i),
                     (np.bincount, (x.name, i), (weights.name, i), minlength))
                     for i, _ in enumerate(x._keys()))
-        dtype = 'f8'
+        dtype = np.bincount([1], weights=[1]).dtype
     else:
         dsk = dict(((name, i),
                     (np.bincount, (x.name, i), None, minlength))
                     for i, _ in enumerate(x._keys()))
-        dtype = 'i8'
+        dtype = np.bincount([]).dtype
 
     # Sum up all of the intermediate bincounts per block
     name = 'bincount-sum-' + token


### PR DESCRIPTION
Previously this hardcoded f8 and i8 dtypes to bincount.
This choice was inaccurate on 32 bit systems.  Now we make a tiny
call to `np.bincount` to determine the appropriate dtype for the
system.

cc @seibert @jcrist 