### PR TITLE
Don't save profiler if file-path not set

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -186,6 +186,6 @@ def visualize(results, dsk, palette='GnBu', file_path=None,
 
     if show:
         bp.show(p)
-    if save:
+    if file_path and save:
         bp.save(p)
     return p


### PR DESCRIPTION
This occurs when using the notebook.