### PR TITLE
CSV error message

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -107,10 +107,18 @@ def fill_kwargs(fn, args, kwargs):
     if 'parse_dates' not in kwargs:
         kwargs['parse_dates'] = [col for col in head.dtypes.index
                            if np.issubdtype(head.dtypes[col], np.datetime64)]
-    if 'dtype' not in kwargs:
-        kwargs['dtype'] = dict(head.dtypes)
+
+    new_dtype = dict(head.dtypes)
+    dtype = kwargs.get('dtype', dict())
+    for k, v in dict(head.dtypes).items():
+        if k not in dtype:
+            dtype[k] = v
+
+    if kwargs.get('parse_dates'):
         for col in kwargs['parse_dates']:
-            del kwargs['dtype'][col]
+            del dtype[col]
+
+    kwargs['dtype'] = dtype
 
     kwargs['columns'] = list(head.columns)
 

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -34,31 +34,31 @@ def _read_csv(fn, i, chunkbytes, compression, kwargs):
         return pd.read_csv(block, **kwargs)
     except ValueError as e:
         msg = """
-        Dask dataframe inspected the first 1,000 rows of your csv file to guess the
-        data types of your columns.  These first 1,000 rows led us to an incorrect
-        guess.
+    Dask dataframe inspected the first 1,000 rows of your csv file to guess the
+    data types of your columns.  These first 1,000 rows led us to an incorrect
+    guess.
 
-        For example a column may have had integers in the first thousand
-        rows followed by a float or missing value in the 1,001-th row.
+    For example a column may have had integers in the first 1000
+    rows followed by a float or missing value in the 1,001-st row.
 
-        You will need to specify some dtype information explicitly using the
-        ``dtype=`` keyword argument for the right column names and dtypes.
+    You will need to specify some dtype information explicitly using the
+    ``dtype=`` keyword argument for the right column names and dtypes.
 
-            df = dd.read_csv(..., dtype={'my-column': float})
+        df = dd.read_csv(..., dtype={'my-column': float})
 
-        Pandas has given us the following error when trying to parse the file:
+    Pandas has given us the following error when trying to parse the file:
 
-        %(pandas_error)s
-        """
-        match = re.match('cannot safely convert passed user dtype of (?P<old_dtype>\S+) for (?P<new_dtype>\S+) dtyped data in column (?P<column_number>\d+)', e.message)
+      "%s"
+        """ % e.args[0]
+        match = re.match('cannot safely convert passed user dtype of (?P<old_dtype>\S+) for (?P<new_dtype>\S+) dtyped data in column (?P<column_number>\d+)', e.args[0])
         if match:
             d = match.groupdict()
             d['column'] = kwargs['names'][int(d['column_number'])]
             msg += """
-        From this we think that you should probably add the following column/dtype
-        pair to your dtype= keyword argument
+    From this we think that you should probably add the following column/dtype
+    pair to your dtype= dictionary
 
-        '%(column)s': '%(new_dtype)s'
+    '%(column)s': '%(new_dtype)s'
         """ % d
 
         # TODO: add more regexes and msg logic here for other pandas errors

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -639,3 +639,16 @@ def test_to_bag():
     assert ddf.to_bag(True).compute(get=get_sync) == list(a.itertuples(True))
     assert ddf.x.to_bag(True).compute(get=get_sync) == list(a.x.iteritems())
     assert ddf.x.to_bag().compute(get=get_sync) == list(a.x)
+
+
+def test_bad_csv():
+    text = 'numbers,names\n'
+    for i in range(1000):
+        text += '1,foo\n'
+    text += '1.5,bar\n'
+    with filetext(text) as fn:
+        try:
+            dd.read_csv(fn).compute()
+            raise ValueError
+        except ValueError as e:
+            assert "dtype={'numbers': float64}" in str(e)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -664,7 +664,7 @@ def test_report_dtype_correction_on_csvs():
     text += '1.5,bar\n'
     with filetext(text) as fn:
         try:
-            dd.read_csv(fn).compute()
+            dd.read_csv(fn).compute(get=get_sync)
             assert False
         except ValueError as e:
-            assert "dtype={'numbers': 'float64'}" in str(e)
+            assert "'numbers': 'float64'" in str(e)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -641,7 +641,7 @@ def test_to_bag():
     assert ddf.x.to_bag().compute(get=get_sync) == list(a.x)
 
 
-def test_bad_csv():
+def test_report_dtype_correction_on_csvs():
     text = 'numbers,names\n'
     for i in range(1000):
         text += '1,foo\n'
@@ -649,6 +649,6 @@ def test_bad_csv():
     with filetext(text) as fn:
         try:
             dd.read_csv(fn).compute()
-            raise ValueError
+            assert False
         except ValueError as e:
-            assert "dtype={'numbers': float64}" in str(e)
+            assert "dtype={'numbers': 'float64'}" in str(e)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -641,6 +641,22 @@ def test_to_bag():
     assert ddf.x.to_bag().compute(get=get_sync) == list(a.x)
 
 
+def test_csv_expands_dtypes():
+    with filetext(text) as fn:
+        a = read_csv(fn, chunkbytes=30, dtype={})
+        a_kwargs = list(a.dask.values())[0][-1]
+
+        b = read_csv(fn, chunkbytes=30)
+        b_kwargs = list(b.dask.values())[0][-1]
+
+        assert a_kwargs['dtype'] == b_kwargs['dtype']
+
+        a = read_csv(fn, chunkbytes=30, dtype={'amount': float})
+        a_kwargs = list(a.dask.values())[0][-1]
+
+        assert a_kwargs['dtype']['amount'] == float
+
+
 def test_report_dtype_correction_on_csvs():
     text = 'numbers,names\n'
     for i in range(1000):


### PR DESCRIPTION
Fixes #551 
Builds off of #646 

```python
In [1]: import dask.dataframe as dd
In [2]: import pandas as pd
In [3]: import numpy as np
In [4]: df1 = pd.DataFrame({'A': [1, 2]})  # int dtype
In [5]: df2 = pd.DataFrame({'A': [np.nan, 3]})  # cast to float
In [6]: df1.to_csv('csv1.csv')
In [7]: df2.to_csv('csv2.csv')
In [8]: df = dd.read_csv('csv*.csv')
In [9]: df.sum().compute()

ValueError: Exception occurred in remote worker.

Something you've asked dask to compute raised an exception.
That exception and the traceback are copied below.
To use pdb, rerun the computation with the keyword argument
    dask.set_options(rerun_exceptions_locally=True)
    or
    dataset.compute(rerun_exceptions_locally=True)

The original exception and traceback follow below:


    Dask dataframe inspected the first 1,000 rows of your csv file to guess the
    data types of your columns.  These first 1,000 rows led us to an incorrect
    guess.

    For example a column may have had integers in the first 1000
    rows followed by a float or missing value in the 1,001-st row.

    You will need to specify some dtype information explicitly using the
    ``dtype=`` keyword argument for the right column names and dtypes.

        df = dd.read_csv(..., dtype={'my-column': float})

    Pandas has given us the following error when trying to parse the file:

      "cannot safely convert passed user dtype of <i8 for float64 dtyped data in column 1"
        
    From this we think that you should probably add the following column/dtype
    pair to your dtype= dictionary

    'A': 'float64'
        

Traceback:
  File "dask/async.py", line 266, in execute_task
    result = _execute_task(task, data)
  File "dask/async.py", line 249, in _execute_task
    return func(*args2)
  File "dask/dataframe/io.py", line 67, in _read_csv
    raise ValueError(msg)
```

This also includes a small refactor of read_csv away from being super-lispy.

There some problems though.  #646 worked by parsing the error message coming from pandas for the  int->float case.  While effective this only supports this single case.  Pandas emits different error messages for different cases.  I've switched to using regexes with the idea that these will be easier to extend as needed.  As of now I'm only supporting the common int->float case.