### PR TITLE
Remove verbose debug message from exception

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -489,15 +489,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 _execute_task(task, data)  # Re-execute locally
             else:
                 raise type(res)(
-                "Exception occurred in remote worker.\n\n"
-                "Something you've asked dask to compute raised an exception.\n"
-                "That exception and the traceback are copied below.\n"
-                "To use pdb, rerun the computation with the keyword argument\n"
-                "    dask.set_options(rerun_exceptions_locally=True)\n"
-                "    or\n"
-                "    dataset.compute(rerun_exceptions_locally=True)\n\n"
-                "The original exception and traceback follow below:\n\n"
-                    + str(res) + "\n\nTraceback:\n" + tb)
+                    str(res) + "\n\nTraceback:\n" + tb)
         state['cache'][key] = res
         finish_task(dsk, key, state, results, keyorder.get)
         for f in posttask_cbs:

--- a/dask/async.py
+++ b/dask/async.py
@@ -488,8 +488,12 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 task = dsk[key]
                 _execute_task(task, data)  # Re-execute locally
             else:
-                raise type(res)(
-                    str(res) + "\n\nTraceback:\n" + tb)
+                raise type(res)('\nRemote Exception:\n'
+                              + '-----------------\n'
+                              + str(res) + '\n\n'
+                              + 'Traceback:\n'
+                              + '----------\n'
+                              + tb)
         state['cache'][key] = res
         finish_task(dsk, key, state, results, keyorder.get)
         for f in posttask_cbs:

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -158,15 +158,15 @@ def test_rerun_exceptions_locally():
     try:
         get({'x': (f,)}, 'x')
     except Exception as e:
-        assert 'remote' in str(e).lower()
+        assert 'execute_task' in str(e).lower()
 
     try:
         get({'x': (f,)}, 'x', rerun_exceptions_locally=True)
     except Exception as e:
-        assert 'remote' not in str(e).lower()
+        assert 'execute_task' not in str(e).lower()
 
     try:
         with dask.set_options(rerun_exceptions_locally=True):
             get({'x': (f,)}, 'x')
     except Exception as e:
-        assert 'remote' not in str(e).lower()
+        assert 'execute_task' not in str(e).lower()


### PR DESCRIPTION
Many error reports that we get don't seem to understand this message.
It may be more direct to give them the underlying error report without
explanation.