### PR TITLE
Add dask.array.cov

### DIFF
--- a/dask/array/NUMPY_LICENSE.txt
+++ b/dask/array/NUMPY_LICENSE.txt
@@ -1,0 +1,30 @@
+Copyright (c) 2005-2015, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the NumPy Developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -4,7 +4,7 @@ from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, choose, where, coarsen, insert, broadcast_to, fromfunction,
         unique, store, squeeze, topk, bincount, histogram, map_blocks, atop,
-        to_hdf5, array)
+        to_hdf5, dot, cov, array)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,
         hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -4,7 +4,7 @@ from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, choose, where, coarsen, insert, broadcast_to, fromfunction,
         unique, store, squeeze, topk, bincount, histogram, map_blocks, atop,
-        to_hdf5)
+        to_hdf5, array)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,
         hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -169,39 +169,10 @@ try:
     from numpy import broadcast_to
 except ImportError:  # pragma: no cover
     # broadcast_to will arrive in numpy v1.10. Until then, it is duplicated
-    # here:
+    # here.
 
-    # Copyright (c) 2005-2015, NumPy Developers.
-    # All rights reserved.
-
-    # Redistribution and use in source and binary forms, with or without
-    # modification, are permitted provided that the following conditions are
-    # met:
-
-    #     * Redistributions of source code must retain the above copyright
-    #        notice, this list of conditions and the following disclaimer.
-
-    #     * Redistributions in binary form must reproduce the above
-    #        copyright notice, this list of conditions and the following
-    #        disclaimer in the documentation and/or other materials provided
-    #        with the distribution.
-
-    #     * Neither the name of the NumPy Developers nor the names of any
-    #        contributors may be used to endorse or promote products derived
-    #        from this software without specific prior written permission.
-
-    # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    # A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    # OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    # LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+    # See https://github.com/numpy/numpy/blob/master/LICENSE.txt
+    # or NUMPY_LICENSE.txt within this directory
     def _maybe_view_as_subclass(original_array, new_array):
         if type(original_array) is not type(new_array):
             # if input was an ndarray subclass and subclasses were OK,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2567,6 +2567,7 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
             ddof = 0
     fact = float(N - ddof)
     if fact <= 0:
+        import warnings
         warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning)
         fact = 0.0
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2511,3 +2511,12 @@ def _vindex_merge(locations, values):
         x[tuple(ind)] = val
 
     return x
+
+
+@wraps(np.array)
+def array(x, dtype=None, ndmin=None):
+    while x.ndim < ndmin:
+        x = x[None, :]
+    if dtype is not None and x.dtype != dtype:
+        x = x.astype(dtype)
+    return x

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1100,6 +1100,9 @@ class Array(Base):
     def imag(self):
         return imag(self)
 
+    def conj(self):
+        return conj(self)
+
 
 normalize_token.register(Array, lambda a: a.name)
 
@@ -2573,6 +2576,6 @@ def cov(m, y=None, rowvar=1, bias=0, ddof=None):
 
     X = X - X.mean(axis=1-axis, keepdims=True)
     if not rowvar:
-        return (dot(X.T, conj(X)) / fact).squeeze()
+        return (dot(X.T, X.conj()) / fact).squeeze()
     else:
-        return (dot(X, conj(X.T)) / fact).squeeze()
+        return (dot(X, X.T.conj()) / fact).squeeze()

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1389,6 +1389,9 @@ def test_cov():
     d = da.from_array(x, chunks=(4, 4))
 
     assert eq(da.cov(d), np.cov(x))
+    assert eq(da.cov(d, rowvar=0), np.cov(x, rowvar=0))
+    assert eq(da.cov(d, ddof=10), np.cov(x, ddof=10))
+    assert eq(da.cov(d, bias=1), np.cov(x, bias=1))
     assert eq(da.cov(d, d), np.cov(x, x))
 
     y = np.arange(8)
@@ -1396,3 +1399,5 @@ def test_cov():
 
     assert eq(da.cov(d, e), np.cov(x, y))
     assert eq(da.cov(e, d), np.cov(y, x))
+
+    assert raises(ValueError, lambda: da.cov(d, ddof=1.5))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1374,3 +1374,10 @@ def test_vindex_merge():
 
 def test_empty_array():
     assert eq(np.arange(0), da.arange(0, chunks=5))
+
+
+def test_array():
+    x = np.ones(5, dtype='i4')
+    d = da.ones(5, chunks=3, dtype='i4')
+    assert eq(da.array(d, ndmin=3, dtype='i8'),
+              np.array(x, ndmin=3, dtype='i8'))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1381,3 +1381,17 @@ def test_array():
     d = da.ones(5, chunks=3, dtype='i4')
     assert eq(da.array(d, ndmin=3, dtype='i8'),
               np.array(x, ndmin=3, dtype='i8'))
+
+
+def test_cov():
+    x = np.arange(56).reshape((7, 8))
+    d = da.from_array(x, chunks=(4, 4))
+
+    assert eq(da.cov(d), np.cov(x))
+    assert eq(da.cov(d, d), np.cov(x, x))
+
+    y = np.arange(8)
+    e = da.from_array(y, chunks=(4,))
+
+    assert eq(da.cov(d, e), np.cov(x, y))
+    assert eq(da.cov(e, d), np.cov(y, x))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -858,7 +858,6 @@ def test_arithmetic():
 
     assert eq(da.logaddexp(a, b), np.logaddexp(x, y))
     assert eq(da.logaddexp2(a, b), np.logaddexp2(x, y))
-    assert eq(da.conj(a + 1j * b), np.conj(x + 1j * y))
     assert eq(da.exp(b), np.exp(y))
     assert eq(da.log(a), np.log(x))
     assert eq(da.log10(a), np.log10(x))
@@ -918,6 +917,8 @@ def test_arithmetic():
     assert eq((a + 1j).real, np.real(x + 1j))
     assert eq(da.imag(a + 1j), np.imag(x + 1j))
     assert eq((a + 1j).imag, np.imag(x + 1j))
+    assert eq(da.conj(a + 1j * b), np.conj(x + 1j * y))
+    assert eq((a + 1j * b).conj(), (x + 1j * y).conj())
 
     assert eq(da.clip(b, 1, 4), np.clip(y, 1, 4))
     assert eq(da.fabs(b), np.fabs(y))


### PR DESCRIPTION
This was a surprisingly easy rip off of `np.cov`.

```python
In [1]: import dask.array as da

In [2]: import numpy as np

In [3]: x = np.arange(3*8).reshape(3, 8)

In [4]: d = da.from_array(x, chunks=(2, 2))

In [5]: da.cov(d, -d)
Out[5]: dask.array<elemwise-dd32546cf9aefc9d8cd615d376c0284b, shape=(6, 6), chunks=((2, 1, 2, 1), (2, 1, 2, 1)), dtype=float64>

In [6]: _.compute()
Out[6]: 
array([[ 6.,  6.,  6., -6., -6., -6.],
       [ 6.,  6.,  6., -6., -6., -6.],
       [ 6.,  6.,  6., -6., -6., -6.],
       [-6., -6., -6.,  6.,  6.,  6.],
       [-6., -6., -6.,  6.,  6.,  6.],
       [-6., -6., -6.,  6.,  6.,  6.]])
```

### TODO

- [ ] add `corrcoef` (this is a fairly easy generalization)
- [x] ensure test coverage 