### PR TITLE
dd.conat now supports axis and join kw

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -687,6 +687,11 @@ class Series(_Frame):
         return Series
 
     @property
+    def _empty_partition(self):
+        """ Return empty dummy to emulate the result """
+        return self._partition_type(name=self.name)
+
+    @property
     def ndim(self):
         """ Return dimensionality """
         return 1
@@ -800,7 +805,8 @@ class Series(_Frame):
     def _get_numeric_data(self, how='any', subset=None):
         return self
 
-    def _validate_axis(self, axis=0):
+    @classmethod
+    def _validate_axis(cls, axis=0):
         if axis not in (0, 'index', None):
             raise ValueError('No axis named {0}'.format(axis))
         # convert to numeric axis
@@ -1009,6 +1015,11 @@ class DataFrame(_Frame):
     def _constructor(self):
         return DataFrame
 
+    @property
+    def _empty_partition(self):
+        """ Return empty dummy to emulate the result """
+        return self._partition_type(columns=self.columns)
+
     def __getitem__(self, key):
         if isinstance(key, (str, unicode)):
             name = self._name + '.' + key
@@ -1172,7 +1183,8 @@ class DataFrame(_Frame):
     def _get_numeric_data(self, how='any', subset=None):
         return self.map_partitions(pd.DataFrame._get_numeric_data)
 
-    def _validate_axis(self, axis=0):
+    @classmethod
+    def _validate_axis(cls, axis=0):
         if axis not in (0, 1, 'index', 'columns', None):
             raise ValueError('No axis named {0}'.format(axis))
         # convert to numeric axis
@@ -1403,9 +1415,7 @@ def elemwise(op, *args, **kwargs):
 
     _name = 'elemwise-' + tokenize(op, kwargs, *args)
 
-    from .io import from_pandas
-    args = [from_pandas(arg, 1) if isinstance(arg, (pd.DataFrame, pd.Series))
-            else arg for arg in args]
+    args = _maybe_from_pandas(args)
 
     from .multi import _maybe_align_partitions
     args = _maybe_align_partitions(args)
@@ -1492,35 +1502,58 @@ def reduction(x, chunk, aggregate, token=None):
     return Scalar(merge(x.dask, dsk, dsk2), b)
 
 
-def _concat_dfs(dfs, name):
+def _concat_dfs(dfs, name, join='outer'):
     """ Internal function to concat dask dict and DataFrame.columns """
     dsk = dict()
     i = 0
+
+    empties = [df._empty_partition for df in dfs]
+    result = pd.concat(empties, axis=0, join=join)
+    if isinstance(result, pd.Series):
+        columns = result.name
+    else:
+        columns = result.columns.tolist()
+
     for df in dfs:
+        if columns != df.columns:
+            df = df[[c for c in columns if c in df.columns]]
+            dsk = merge(dsk, df.dask)
+
         for key in df._keys():
             dsk[(name, i)] = key
             i += 1
 
-    empties = [pd.DataFrame(columns=df.columns) for df in dfs]
-    columns = pd.concat(empties, axis=0, join='outer').columns
-
     return dsk, columns
 
+def _maybe_from_pandas(dfs):
+    from .io import from_pandas
+    dfs = [from_pandas(df, 1) if isinstance(df, (pd.DataFrame, pd.Series))
+           else df for df in dfs]
+    return dfs
 
-def concat(dfs, interleave_partitions=False):
+
+def concat(dfs, axis=0, join='outer', interleave_partitions=False):
     """ Concatenate DataFrames along rows.
 
-    - If all divisions are known and ordered, concatenate DataFrames keeping
-      divisions. When divisions are not ordered, specifying
-      interleave_partition=True allows concatenate divisions each by each.
-    - If any of division is unknown, concatenate DataFrames resetting its
-      division to unknown (None)
+    - When axis=0 (default), concatenate DataFrames row-wise:
+      - If all divisions are known and ordered, concatenate DataFrames keeping
+        divisions. When divisions are not ordered, specifying
+        interleave_partition=True allows concatenate divisions each by each.
+      - If any of division is unknown, concatenate DataFrames resetting its
+        division to unknown (None)
+    - When axis=1, concatenate DataFrames column-wise:
+      - Allowed if all divisions are known.
+      - If any of division is unknown, it raises ValueError.
 
     Parameters
     ----------
 
     dfs: list
         List of dask.DataFrames to be concatenated
+    axis: {0, 1, 'index', 'columns'}, default 0
+        The axis to concatenate along
+    join : {'inner', 'outer'}, default 'outer'
+        How to handle indexes on other axis
     interleave_partitions: bool, default False
         Whether to concatenate DataFrames ignoring its order. If True, every
         divisions are concatenated each by each.
@@ -1562,38 +1595,59 @@ def concat(dfs, interleave_partitions=False):
     if len(dfs) == 0:
         raise ValueError('Input must be a list longer than 0')
 
-    if all(df.known_divisions for df in dfs):
-        # each DataFrame's division must be greater than previous one
-        if all(dfs[i].divisions[-1] < dfs[i + 1].divisions[0]
-               for i in range(len(dfs) - 1)):
-            name = 'concat-{0}'.format(tokenize(*dfs))
-            dsk, columns = _concat_dfs(dfs, name)
+    if not join in ('inner', 'outer'):
+        raise ValueError("'join' must be 'inner' or 'outer'")
 
-            divisions = []
-            for df in dfs[:-1]:
-                # remove last to concatenate with next
-                divisions += df.divisions[:-1]
-            divisions += dfs[-1].divisions
+    axis = DataFrame._validate_axis(axis)
+    dasks = [df for df in dfs if isinstance(df, _Frame)]
 
-            return DataFrame(merge(dsk, *[df.dask for df in dfs]), name,
-                             columns, divisions)
+    if all(df.known_divisions for df in dasks):
+        # must be converted here to check whether divisions can be
+        # concatenated
+        dfs = _maybe_from_pandas(dfs)
+        if axis == 1:
+            from .multi import concat_indexed_dataframes
+            return concat_indexed_dataframes(dfs, axis=axis, join=join)
         else:
-            if interleave_partitions:
-                from .multi import concat_indexed_dataframes
-                return concat_indexed_dataframes(dfs)
+            # each DataFrame's division must be greater than previous one
+            if all(dfs[i].divisions[-1] < dfs[i + 1].divisions[0]
+                   for i in range(len(dfs) - 1)):
+                name = 'concat-{0}'.format(tokenize(*dfs))
+                dsk, columns = _concat_dfs(dfs, name, join=join)
 
-            raise ValueError('All inputs have known divisions which cannnot be '
-                             'concatenated in order. Specify '
-                             'interleave_partitions=True to ignore order')
+                divisions = []
+                for df in dfs[:-1]:
+                    # remove last to concatenate with next
+                    divisions += df.divisions[:-1]
+                divisions += dfs[-1].divisions
+
+                return_type = _get_return_type(dfs[0], columns)
+                return return_type(merge(dsk, *[df.dask for df in dfs]), name,
+                                   columns, divisions)
+            else:
+                if interleave_partitions:
+                    from .multi import concat_indexed_dataframes
+                    return concat_indexed_dataframes(dfs, join=join)
+
+                raise ValueError('All inputs have known divisions which cannnot '
+                                 'be concatenated in order. Specify '
+                                 'interleave_partitions=True to ignore order')
 
     else:
-        name = 'concat-{0}'.format(tokenize(*dfs))
-        dsk, columns = _concat_dfs(dfs, name)
+        if axis == 1:
+             raise ValueError('Unable to concatenate DataFrame with unknown '
+                              'division specifying axis=1')
+        else:
+            # concat will not regard Series as row
+            dfs = _maybe_from_pandas(dfs)
+            name = 'concat-{0}'.format(tokenize(*dfs))
+            dsk, columns = _concat_dfs(dfs, name, join=join)
 
-        divisions = [None] * (len(dsk) + 1)
+            divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
 
-        return DataFrame(merge(dsk, *[df.dask for df in dfs]), name,
-                         columns, divisions)
+            return_type = _get_return_type(dfs[0], columns)
+            return return_type(merge(dsk, *[df.dask for df in dfs]), name,
+                               columns, divisions)
 
 
 def _groupby_apply(df, ind, func):
@@ -1867,6 +1921,15 @@ aca = apply_concat_apply
 
 
 def _get_return_type(arg, columns):
+    """ Get the class of the result
+
+    - When columns is str/unicode, the result is:
+       - Scalar when columns is ``return_scalar``
+       - Index if arg is Index
+       - Series otherwise
+    - Otherwise, result is DataFrame.
+    """
+
     if (isinstance(columns, (str, unicode)) or not
           isinstance(columns, Iterable)):
 
@@ -1900,9 +1963,7 @@ def map_partitions(func, columns, *args, **kwargs):
         dask = {(name, 0): (func, ) + tuple((arg._name, 0) for arg in args)}
         return Scalar(merge(dask, *[arg.dask for arg in args]), name)
 
-    from .io import from_pandas
-    args = [from_pandas(arg, 1) if isinstance(arg, (pd.DataFrame, pd.Series))
-            else arg for arg in args]
+    args = _maybe_from_pandas(args)
 
     if columns is no_default:
         columns = None


### PR DESCRIPTION
``dd.concat`` now accepts ``axis`` and ``join`` kwds, and also can handle ``pd.DataFrame`` and ``pd.Series``

```
import pandas as pd
import dask.dataframe as dd
pdf1 = pd.DataFrame(np.random.randn(5, 3),
                    columns=list('ABC'), index=list('abcde'))
pdf2 = pd.DataFrame(np.random.randn(5, 3),
                    columns=list('BCD'), index=list('cdefg'))

ddf1 = dd.from_pandas(pdf1, 2)
ddf2 = dd.from_pandas(pdf2, 3)

dd.concat([ddf1, ddf2], join='inner', interleave_partitions=True).compute()
#           B         C
# a  0.057368 -0.114980
# b  1.343076 -0.187848
# c  1.339602  0.818056
# c -0.745348 -0.833845
# d -1.220426  0.099875
# d  0.415294  0.021301
# e -1.305663 -0.681339
# e -0.989652  1.031010
# f -1.845416 -1.029631
# g -1.241760 -0.653383

dd.concat([ddf1, ddf2], axis=1).compute()
#           A         B         C         B         C         D
# a  0.061261  0.057368 -0.114980       NaN       NaN       NaN
# b  1.102111  1.343076 -0.187848       NaN       NaN       NaN
# c -0.086301  1.339602  0.818056 -0.745348 -0.833845  2.215104
# d -1.155713 -1.220426  0.099875  0.415294  0.021301 -0.400563
# e  0.366453 -1.305663 -0.681339 -0.989652  1.031010  0.342009
# f        NaN       NaN       NaN -1.845416 -1.029631 -0.226682
# g       NaN       NaN       NaN -1.241760 -0.653383  1.235325
```
