### PR TITLE
Support multiple gets within single Profiler run

### DIFF
--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -76,13 +76,6 @@ class Profiler(Callback):
         self.results += list(starmap(TaskData, results.values()))
         self._results.clear()
 
-    def results(self):
-        """Returns a list containing namedtuples of:
-
-        TaskData(key, task, start_time, end_time, worker_id)"""
-
-        return
-
     def visualize(self, **kwargs):
         """Visualize the profiling run in a bokeh plot.
 

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -45,8 +45,11 @@ class Profiler(Callback):
         self._results = {}
         self._dsk = {}
 
-    def _start(self, dsk):
+    def __enter__(self):
         self.clear()
+        return super(Profiler, self).__enter__()
+
+    def _start(self, dsk):
         self._dsk = dsk.copy()
 
     def _pretask(self, key, dsk, state):

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -40,6 +40,16 @@ class Profiler(Callback):
     method. Note that this requires bokeh to be installed.
 
     >>> prof.visualize() # doctest: +SKIP
+
+    You can activate the profiler globally
+
+    >>> prof.register()  # doctest: +SKIP
+
+    If you use the profiler globally you will need to clear out old results
+    manually.
+
+    >>> prof.clear()
+
     """
     def __init__(self):
         self._results = {}

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -26,13 +26,13 @@ def test_profiler():
     with prof:
         out = get(dsk, 'e')
     assert out == 6
-    prof_data = sorted(prof.results(), key=lambda d: d.key)
+    prof_data = sorted(prof.results, key=lambda d: d.key)
     keys = [i.key for i in prof_data]
     assert keys == ['c', 'd', 'e']
     tasks = [i.task for i in prof_data]
     assert tasks == [(add, 'a', 'b'), (mul, 'a', 'b'), (mul, 'c', 'd')]
     prof.clear()
-    assert prof.results() == []
+    assert prof.results == []
 
 
 def test_profiler_works_under_error():
@@ -43,8 +43,8 @@ def test_profiler_works_under_error():
         with prof:
             out = get(dsk, 'z')
 
-    assert all(len(v) == 5 for v in prof.results())
-    assert len(prof.results()) == 2
+    assert all(len(v) == 5 for v in prof.results)
+    assert len(prof.results) == 2
 
 
 @pytest.mark.skipif("not bokeh")
@@ -118,16 +118,17 @@ def test_get_colors():
 def test_two_gets():
     with prof:
         get(dsk, 'e')
-    n = len(prof.results())
+    n = len(prof.results)
 
     dsk2 = {'x': (add, 1, 2), 'y': (add, 'x', 'x')}
 
     with prof:
         get(dsk2, 'y')
-    m = len(prof.results())
+    m = len(prof.results)
 
     with prof:
         get(dsk, 'e')
         get(dsk2, 'y')
+        get(dsk, 'e')
 
-    assert len(prof.results()) == m + n
+    assert len(prof.results) == n + m + n

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -113,3 +113,21 @@ def test_get_colors():
     cmap = get_colors('BrBG', funcs)
     lk = dict(zip([0, 1], BrBG3))
     assert cmap == [lk[i] for i in funcs]
+
+
+def test_two_gets():
+    with prof:
+        get(dsk, 'e')
+    n = len(prof.results())
+
+    dsk2 = {'x': (add, 1, 2), 'y': (add, 'x', 'x')}
+
+    with prof:
+        get(dsk2, 'y')
+    m = len(prof.results())
+
+    with prof:
+        get(dsk, 'e')
+        get(dsk2, 'y')
+
+    assert len(prof.results()) == m + n

--- a/docs/source/diagnostics.rst
+++ b/docs/source/diagnostics.rst
@@ -70,8 +70,7 @@ list of ``namedtuple`` objects containing the data for each task.
 
 .. code-block:: python
 
-    >>> data = prof.results()
-    >>> data[0]  # doctest: +SKIP
+    >>> prof.results[0]  # doctest: +SKIP
     TaskData(key=('tsqr_1_QR_st1', 9, 0),
              task=(qr, (_apply_random, 'random_sample', 1730327976, (1000, 1000), (), {})),
              start_time=1435613641.833878,


### PR DESCRIPTION
Sometimes one computation spans multiple calls to `get`.  This resets the profiler at the context manager's start/exit rather than get's start/finish.