### PR TITLE
Index dt properties

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1328,6 +1328,14 @@ for name in ['add', 'sub', 'mul', 'div',
     Series._bind_operator_method(name, meth)
 
 
+def elemwise_property(attr, s):
+    return map_partitions(getattr, s.name, s, attr)
+
+for name in ['nanosecond', 'microsecond', 'millisecond', 'second', 'minute',
+        'hour', 'day', 'week', 'month', 'quarter', 'year']:
+    setattr(Index, name, property(partial(elemwise_property, name)))
+
+
 def _assign(df, *pairs):
     kwargs = dict(partition(2, pairs))
     return df.assign(**kwargs)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1903,6 +1903,9 @@ def test_datetime_accessor():
     assert eq(a.x.dt.date, df.x.dt.date, check_names=False)
     assert (a.x.dt.to_pydatetime().compute() == df.x.dt.to_pydatetime()).all()
 
+    assert a.x.dt.date.dask == a.x.dt.date.dask
+    assert a.x.dt.to_pydatetime().dask == a.x.dt.to_pydatetime().dask
+
 
 def test_str_accessor():
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'D']})
@@ -1912,6 +1915,8 @@ def test_str_accessor():
     assert 'upper' in dir(a.x.str)
 
     assert eq(a.x.str.upper(), df.x.str.upper())
+
+    assert a.x.str.upper().dask == a.x.str.upper().dask
 
 
 def test_empty_max():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2118,3 +2118,11 @@ def test_apply():
 
     func = lambda x: pd.Series([x, x])
     eq(a.x.apply(func, name=[0, 1]), df.x.apply(func))
+
+
+def test_index_time_properties():
+    i = tm.makeTimeSeries()
+    a = dd.from_pandas(i, npartitions=3)
+
+    assert (i.index.day == a.index.day.compute()).all()
+    assert (i.index.month == a.index.month.compute()).all()


### PR DESCRIPTION
Two changes

1.  Add `hour`, `minute`, etc. properties to `dd.Index`
2.  Clean up the `DatetimeAccessor` and `StringAccessor` classes