### PR TITLE
DataFrame.__getitem__ now accepts non-str

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1021,8 +1021,8 @@ class DataFrame(_Frame):
         return self._partition_type(columns=self.columns)
 
     def __getitem__(self, key):
-        if isinstance(key, (str, unicode)):
-            name = self._name + '.' + key
+        if np.isscalar(key):
+            name = '{0}.{1}'.format(self._name, key)
             if key in self.columns:
                 dsk = dict(((name, i), (operator.getitem, (self._name, i), key))
                             for i in range(self.npartitions))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1421,6 +1421,15 @@ def test_getitem():
     assert raises(KeyError, lambda: df[['A', 'X']])
     assert raises(AttributeError, lambda: df.X)
 
+    # not str/unicode
+    df = pd.DataFrame(np.random.randn(10, 5))
+    ddf = dd.from_pandas(df, 2)
+    assert eq(ddf[0], df[0])
+    assert eq(ddf[[1, 2]], df[[1, 2]])
+
+    assert raises(KeyError, lambda: df[8])
+    assert raises(KeyError, lambda: df[[1, 8]])
+
 
 def test_assign():
     assert eq(d.assign(c=d.a + 1, e=d.a + d.b),


### PR DESCRIPTION
Follow-up of #666. It raises ``NotImplementedError`` when columns are not ``str/unicode``. Fixed to handle scalar properly.

```
# current master
import numpy as np
import pandas as pd
import dask.dataframe as dd
df = pd.DataFrame(np.random.randn(10, 5))
ddf = dd.from_pandas(df, 2)
ddf[0]
# NotImplementedError: 0
```