### PR TITLE
Fix AttributeError caused by pandas.groupby change

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1726,8 +1726,8 @@ class _GroupBy(object):
     def max(self):
         return self._aca_agg(token='max', func=lambda x: x.max())
 
-    @wraps(pd.core.groupby.GroupBy.count)
     def count(self):
+        """ Compute count of groups """
         return self._aca_agg(token='count', func=lambda x: x.count(),
                              aggfunc=lambda x: x.sum())
 


### PR DESCRIPTION
Closes #679.

``count`` is now defined in ``DataFrameGroupBy`` and ``SeriesGroupBy``. 
I found there is no docstring in [``GroupBy.count``](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.core.groupby.GroupBy.count.html#pandas.core.groupby.GroupBy.count), thus no need to use ``@wraps`` here.