### PR TITLE
Add dask.dataframe.nlargest

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -885,9 +885,7 @@ class Series(_Frame):
 
     @wraps(pd.Series.nlargest)
     def nlargest(self, n=5):
-        f = lambda s: s.nlargest(n)
-        token = 'series-nlargest-n={0}'.format(n)
-        return aca(self, f, f, columns=self.name, token=token)
+        return nlargest(self, n)
 
     @wraps(pd.Series.isin)
     def isin(self, other):
@@ -1101,6 +1099,10 @@ class DataFrame(_Frame):
     def column_info(self):
         """ Return DataFrame.columns """
         return self.columns
+
+    @wraps(pd.DataFrame.nlargest)
+    def nlargest(self, n=5, columns=None):
+        return nlargest(self, n, columns)
 
     @wraps(pd.DataFrame.groupby)
     def groupby(self, key, **kwargs):
@@ -1334,6 +1336,17 @@ def elemwise_property(attr, s):
 for name in ['nanosecond', 'microsecond', 'millisecond', 'second', 'minute',
         'hour', 'day', 'week', 'month', 'quarter', 'year']:
     setattr(Index, name, property(partial(elemwise_property, name)))
+
+
+def nlargest(df, n=5, columns=None):
+    if isinstance(df, Series):
+        token = 'series-nlargest-n={0}'.format(n)
+        f = lambda s: s.nlargest(n)
+    elif isinstance(df, DataFrame):
+        token = 'dataframe-nlargest-n={0}'.format(n)
+        f = lambda df: df.nlargest(n, columns)
+        columns = df.columns  # this is a hack.
+    return aca(df, f, f, columns=columns, token=token)
 
 
 def _assign(df, *pairs):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1342,7 +1342,9 @@ for name in ['nanosecond', 'microsecond', 'millisecond', 'second', 'minute',
 
 
 def nlargest(df, n=5, columns=None):
-    if isinstance(df, Series):
+    if isinstance(df, Index):
+        raise AttributeError("nlargest is not available for Index objects")
+    elif isinstance(df, Series):
         token = 'series-nlargest-n={0}'.format(n)
         f = lambda s: s.nlargest(n)
     elif isinstance(df, DataFrame):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1100,8 +1100,11 @@ class DataFrame(_Frame):
         """ Return DataFrame.columns """
         return self.columns
 
-    @wraps(pd.DataFrame.nlargest)
     def nlargest(self, n=5, columns=None):
+        """
+        Return the rows which contain the largest n elements from the provided
+        column, in descending order.
+        """
         return nlargest(self, n, columns)
 
     @wraps(pd.DataFrame.groupby)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,6 +1,7 @@
 from itertools import product
 from datetime import datetime
 from operator import getitem
+from distutils.version import LooseVersion
 
 import pandas as pd
 import pandas.util.testing as tm
@@ -2142,6 +2143,8 @@ def test_index_time_properties():
     assert (i.index.month == a.index.month.compute()).all()
 
 
+@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.16.2',
+        reason="nlargest not in pandas pre 0.16.2")
 def test_nlargest():
     from string import ascii_lowercase
     df = pd.DataFrame({'a': np.random.permutation(10),
@@ -2153,6 +2156,8 @@ def test_nlargest():
     eq(res, exp)
 
 
+@pytest.mark.skipif(LooseVersion(pd.__version__) <= '0.16.2',
+        reason="nlargest not in pandas pre 0.16.2")
 def test_nlargest_multiple_columns():
     from string import ascii_lowercase
     df = pd.DataFrame({'a': np.random.permutation(10),

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2140,3 +2140,26 @@ def test_index_time_properties():
 
     assert (i.index.day == a.index.day.compute()).all()
     assert (i.index.month == a.index.month.compute()).all()
+
+
+def test_nlargest():
+    from string import ascii_lowercase
+    df = pd.DataFrame({'a': np.random.permutation(10),
+                       'b': list(ascii_lowercase[:10])})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    res = ddf.nlargest(5, 'a')
+    exp = df.nlargest(5, 'a')
+    eq(res, exp)
+
+
+def test_nlargest_multiple_columns():
+    from string import ascii_lowercase
+    df = pd.DataFrame({'a': np.random.permutation(10),
+                       'b': list(ascii_lowercase[:10]),
+                       'c': np.random.permutation(10).astype('float64')})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    result = ddf.nlargest(5, ['a', 'b'])
+    expected = df.nlargest(5, ['a', 'b'])
+    eq(result, expected)


### PR DESCRIPTION
closes #317

Note that this duplicates pandas behavior, which I think is a bit unexpected. The dataframe is sorted by the `nlargest` elements of the first thing in the `columns` argument that is passed in, then all the columns are returned. Not just the ones in `columns`.
```python
In [1]: import pandas; from string import ascii_lowercase; import numpy as np

In [2]: a = pandas.DataFrame({'a': np.random.permutation(10),
'b': list(ascii_lowercase[:10]),
'c': np.random.permutation(10).astype('float64')})

In [3]: a.nlargest(5, 'a')
Out[3]: 
   a  b  c
2  9  c  2
4  8  e  3
6  7  g  9
3  6  d  5
7  5  h  7

In [4]: a.nlargest(5, ['a', 'b'])
Out[4]: 
   a  b  c
2  9  c  2
4  8  e  3
6  7  g  9
3  6  d  5
7  5  h  7
```