### PR TITLE
Clean map partitions

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1977,15 +1977,14 @@ def map_partitions(func, columns, *args, **kwargs):
     targets: list
         List of target DataFrame / Series.
     """
+    assert callable(func)
     token = kwargs.pop('token', 'map-partitions')
     token_key = tokenize(token or func, columns, *args)
     name = '{0}-{1}'.format(token, token_key)
 
-    if len(kwargs) > 1:
-        func = partial(func, **kwargs)
-
     if all(isinstance(arg, Scalar) for arg in args):
-        dask = {(name, 0): (func, ) + tuple((arg._name, 0) for arg in args)}
+        dask = {(name, 0):
+                (apply, func, (tuple, [(arg._name, 0) for arg in args]), kwargs)}
         return Scalar(merge(dask, *[arg.dask for arg in args]), name)
 
     args = _maybe_from_pandas(args)
@@ -2002,7 +2001,8 @@ def map_partitions(func, columns, *args, **kwargs):
     for i in range(dfs[0].npartitions):
         values = [(arg._name, i if isinstance(arg, _Frame) else 0)
                   if isinstance(arg, (_Frame, Scalar)) else arg for arg in args]
-        dsk[(name, i)] = (_rename, columns, (apply, func, (tuple, values)))
+        dsk[(name, i)] = (_rename, columns, (apply, func, (tuple, values),
+                                                          kwargs))
 
     dasks = [arg.dask for arg in args if isinstance(arg, (_Frame, Scalar))]
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -778,18 +778,18 @@ class Series(_Frame):
         day_nanos = pd.datetools.Day().nanos
 
         rule = pd.datetools.to_offset(rule)
-        def block_func(df):
-            if getattr(rule, 'nanos', None) and day_nanos % rule.nanos:
-                raise NotImplementedError('Resampling frequency %s that does'
-                                          ' not evenly divide a day is not '
-                                          'implemented' % rule)
 
-            return df.resample(rule=rule, how=how, axis=axis,
-                               fill_method=fill_method, closed=closed,
-                               label=label, convention=convention, kind=kind,
-                               loffset=loffset, limit=limit, base=base)
+        if getattr(rule, 'nanos', None) and day_nanos % rule.nanos:
+            raise NotImplementedError('Resampling frequency %s that does'
+                                      ' not evenly divide a day is not '
+                                      'implemented' % rule)
 
-        return self.repartition(newdivs, force=True).map_partitions(block_func)
+        return map_partitions(pd.Series.resample, self.name,
+                self.repartition(newdivs, force=True),
+                rule=rule, how=how, axis=axis,
+                fill_method=fill_method, closed=closed, label=label,
+                convention=convention, kind=kind, loffset=loffset, limit=limit,
+                base=base)
 
     def __getitem__(self, key):
         if isinstance(key, Series) and self.divisions == key.divisions:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1979,7 +1979,7 @@ def map_partitions(func, columns, *args, **kwargs):
     """
     assert callable(func)
     token = kwargs.pop('token', 'map-partitions')
-    token_key = tokenize(token or func, columns, *args)
+    token_key = tokenize(token or func, columns, kwargs, *args)
     name = '{0}-{1}'.format(token, token_key)
 
     if all(isinstance(arg, Scalar) for arg in args):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1171,6 +1171,8 @@ def test_map_partitions_keeps_kwargs_in_dict():
     assert "'x': 5" in str(b.dask)
     eq(df.x + 5, b)
 
+    assert a.x.map_partitions(f, x=5)._name != a.x.map_partitions(f, x=6)._name
+
 
 def test_drop_duplicates():
     assert eq(d.a.drop_duplicates(), full.a.drop_duplicates())

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1158,6 +1158,20 @@ def test_map_partitions_method_names():
     assert b.name == 'x'
 
 
+def test_map_partitions_keeps_kwargs_in_dict():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
+    a = dd.from_pandas(df, npartitions=2)
+
+
+    def f(s, x=1):
+        return s + x
+
+    b = a.x.map_partitions(f, x=5)
+
+    assert "'x': 5" in str(b.dask)
+    eq(df.x + 5, b)
+
+
 def test_drop_duplicates():
     assert eq(d.a.drop_duplicates(), full.a.drop_duplicates())
     assert eq(d.drop_duplicates(), full.drop_duplicates())


### PR DESCRIPTION
This exposes kwargs used in map_partitions in the graph, improving our ability to inspect graphs.

This avoids a closure in `resample`, again improving our ability to inspect those graphs.