### PR TITLE
DataFrame cleanups

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -1,9 +1,9 @@
-from .core import (DataFrame, Series, Index, _Frame, concat, map_partitions,
+from .core import (DataFrame, Series, Index, _Frame, map_partitions,
         repartition)
 from .io import (read_csv, from_array, from_bcolz, from_array, from_bcolz,
                  from_pandas, from_dask_array, from_castra, read_hdf)
 from .optimize import optimize
-from .multi import merge
+from .multi import merge, concat
 from .rolling import (rolling_count, rolling_sum, rolling_mean, rolling_median,
                       rolling_min, rolling_max, rolling_std, rolling_var,
                       rolling_skew, rolling_kurt, rolling_quantile, rolling_apply,

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -19,7 +19,7 @@ from .. import array as da
 from ..async import get_sync
 
 from . import core
-from .core import DataFrame, Series, concat, categorize_block
+from .core import DataFrame, Series, categorize_block
 from .shuffle import set_partition
 
 
@@ -149,6 +149,7 @@ def read_csv(fn, *args, **kwargs):
 
     # Handle glob strings
     if '*' in fn:
+        from .multi import concat
         return concat([read_csv(f, *args, **kwargs) for f in sorted(glob(fn))])
 
     token = tokenize(os.path.getmtime(fn), args, kwargs)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -55,10 +55,12 @@ We proceed with hash joins in the following stages:
 """
 
 from ..base import tokenize
-from .core import (repartition, _get_return_type, _Frame, Scalar, DataFrame,
-                   Index)
+from .core import (_get_return_type, _Frame, Scalar, DataFrame,
+                   Index, _maybe_from_pandas)
 from .io import from_pandas
 from .shuffle import shuffle
+from . import utils
+
 from bisect import bisect_left, bisect_right
 from toolz import merge_sorted, unique, partial
 import toolz
@@ -197,24 +199,26 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
     (lhs, rhs), divisions, parts = align_partitions(lhs, rhs)
     divisions, parts = require(divisions, parts, required[how])
 
-    left_empty = pd.DataFrame(columns=lhs.columns)
-    right_empty = pd.DataFrame(columns=rhs.columns)
+    left_empty = lhs._empty_partition
+    right_empty = rhs._empty_partition
 
     name = 'join-indexed-' + tokenize(lhs, rhs, how, lsuffix, rsuffix)
-    dsk = dict(((name, i),
-                (pd.DataFrame.join, a, b, None, how, lsuffix, rsuffix)
-                if a is not None and b is not None else
-                (pd.DataFrame.join, a, right_empty, None, how, lsuffix, rsuffix)
-                if a is not None and how in ('left', 'outer') else
-                (pd.DataFrame.join, left_empty, b, None, how, lsuffix, rsuffix)
-                if b is not None and how in ('right', 'outer') else
-                None)
-                for i, (a, b) in enumerate(parts))
+
+    dsk = dict()
+    for i, (a, b) in enumerate(parts):
+        if a is None and how in ('right', 'outer'):
+            a = left_empty
+        if b is None and how in ('left', 'outer'):
+            b = right_empty
+
+        dsk[(name, i)] = (pd.DataFrame.join, a, b, None, how,
+                          lsuffix, rsuffix)
 
     # fake column names
     j = left_empty.join(right_empty, None, how, lsuffix, rsuffix)
 
-    return DataFrame(toolz.merge(lhs.dask, rhs.dask, dsk), name, j.columns, divisions)
+    return DataFrame(toolz.merge(lhs.dask, rhs.dask, dsk), name,
+                     j.columns, divisions)
 
 
 def pdmerge(left, right, how, left_on, right_on,
@@ -262,8 +266,8 @@ def hash_join(lhs, left_on, rhs, right_on, how='inner',
         right_index = False
 
     # fake column names
-    left_empty = pd.DataFrame(columns=lhs.columns)
-    right_empty = pd.DataFrame(columns=rhs.columns)
+    left_empty = lhs._empty_partition
+    right_empty = rhs._empty_partition
     j = pd.merge(left_empty, right_empty, how, None,
                  left_on=left_on, right_on=right_on,
                  left_index=left_index, right_index=right_index,
@@ -310,12 +314,14 @@ def _pdconcat(dfs, axis=0, join='outer'):
             first = [df for df in dfs if len(df) > 0][0]
 
             def _pad(base, fillby):
-                # use aligned index to keep index for outer concat
-                return pd.Series([np.nan] * len(fillby),
-                                  index=fillby.index, name=base.name)
+                if isinstance(base, pd.Series) and len(base) == 0:
+                    # use aligned index to keep index for outer concat
+                    return pd.Series([np.nan] * len(fillby),
+                                      index=fillby.index, name=base.name)
+                else:
+                    return base
 
-            dfs = [_pad(df, first) if isinstance(df, pd.Series) and len(df) == 0
-                   else df for df in dfs]
+            dfs = [_pad(df, first) for df in dfs]
         else:
             # inner concat should result in empty if any input is empty
             if any(len(df) == 0 for df in dfs):
@@ -370,21 +376,21 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
         left_on = right_on = on
         on = None
 
-    if (isinstance(left, pd.core.generic.NDFrame) and
-        isinstance(right, pd.core.generic.NDFrame)):
+    if (utils.is_frame_or_series(left) and
+        utils.is_frame_or_series(right)):
         return pd.merge(left, right, how=how, on=on, left_on=left_on,
                         right_on=right_on, left_index=left_index,
                         right_index=right_index, suffixes=suffixes)
 
     # Transform pandas objects into dask.dataframe objects
-    if isinstance(left, pd.core.generic.NDFrame):
+    if utils.is_frame_or_series(left):
         if right_index and left_on:  # change to join on index
             left = left.set_index(left[left_on])
             left_on = False
             left_index = True
         left = from_pandas(left, npartitions=1)  # turn into DataFrame
 
-    if isinstance(right, pd.core.generic.NDFrame):
+    if utils.is_frame_or_series(right):
         if left_index and right_on:  # change to join on index
             right = right.set_index(right[right_on])
             right_on = False
@@ -402,3 +408,144 @@ def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
                          right, right.index if right_index else right_on,
                          how, npartitions, suffixes)
 
+
+def _concat_dfs(dfs, name, join='outer'):
+    """ Internal function to concat dask dict and DataFrame.columns """
+    dsk = dict()
+    i = 0
+
+    empties = [df._empty_partition for df in dfs]
+    result = pd.concat(empties, axis=0, join=join)
+    if isinstance(result, pd.Series):
+        columns = result.name
+    else:
+        columns = result.columns.tolist()
+
+    for df in dfs:
+        if columns != df.columns:
+            df = df[[c for c in columns if c in df.columns]]
+            dsk = toolz.merge(dsk, df.dask)
+
+        for key in df._keys():
+            dsk[(name, i)] = key
+            i += 1
+
+    return dsk, columns
+
+
+def concat(dfs, axis=0, join='outer', interleave_partitions=False):
+    """ Concatenate DataFrames along rows.
+
+    - When axis=0 (default), concatenate DataFrames row-wise:
+      - If all divisions are known and ordered, concatenate DataFrames keeping
+        divisions. When divisions are not ordered, specifying
+        interleave_partition=True allows concatenate divisions each by each.
+      - If any of division is unknown, concatenate DataFrames resetting its
+        division to unknown (None)
+    - When axis=1, concatenate DataFrames column-wise:
+      - Allowed if all divisions are known.
+      - If any of division is unknown, it raises ValueError.
+
+    Parameters
+    ----------
+
+    dfs: list
+        List of dask.DataFrames to be concatenated
+    axis: {0, 1, 'index', 'columns'}, default 0
+        The axis to concatenate along
+    join : {'inner', 'outer'}, default 'outer'
+        How to handle indexes on other axis
+    interleave_partitions: bool, default False
+        Whether to concatenate DataFrames ignoring its order. If True, every
+        divisions are concatenated each by each.
+
+    Examples
+    --------
+
+    # If all divisions are known and ordered, divisions are kept.
+    >>> a                                               # doctest: +SKIP
+    dd.DataFrame<x, divisions=(1, 3, 5)>
+    >>> b                                               # doctest: +SKIP
+    dd.DataFrame<y, divisions=(6, 8, 10)>
+    >>> dd.concat([a, b])                               # doctest: +SKIP
+    dd.DataFrame<concat-..., divisions=(1, 3, 6, 8, 10)>
+
+    # Unable to concatenate if divisions are not ordered.
+    >>> a                                               # doctest: +SKIP
+    dd.DataFrame<x, divisions=(1, 3, 5)>
+    >>> b                                               # doctest: +SKIP
+    dd.DataFrame<y, divisions=(2, 3, 6)>
+    >>> dd.concat([a, b])                               # doctest: +SKIP
+    ValueError: All inputs have known divisions which cannnot be concatenated
+    in order. Specify interleave_partitions=True to ignore order
+
+    # Specify interleave_partitions=True to ignore the division order.
+    >>> dd.concat([a, b], interleave_partitions=True)   # doctest: +SKIP
+    dd.DataFrame<concat-..., divisions=(1, 2, 3, 5, 6)>
+
+    # If any of division is unknown, the result division will be unknown
+    >>> a                                               # doctest: +SKIP
+    dd.DataFrame<x, divisions=(None, None)>
+    >>> b                                               # doctest: +SKIP
+    dd.DataFrame<y, divisions=(1, 4, 10)>
+    >>> dd.concat([a, b])                               # doctest: +SKIP
+    dd.DataFrame<concat-..., divisions=(None, None, None, None)>
+    """
+    if not isinstance(dfs, list):
+        dfs = [dfs]
+    if len(dfs) == 0:
+        raise ValueError('Input must be a list longer than 0')
+
+    if not join in ('inner', 'outer'):
+        raise ValueError("'join' must be 'inner' or 'outer'")
+
+    axis = DataFrame._validate_axis(axis)
+    dasks = [df for df in dfs if isinstance(df, _Frame)]
+
+    if all(df.known_divisions for df in dasks):
+        # must be converted here to check whether divisions can be
+        # concatenated
+        dfs = _maybe_from_pandas(dfs)
+        if axis == 1:
+            from .multi import concat_indexed_dataframes
+            return concat_indexed_dataframes(dfs, axis=axis, join=join)
+        else:
+            # each DataFrame's division must be greater than previous one
+            if all(dfs[i].divisions[-1] < dfs[i + 1].divisions[0]
+                   for i in range(len(dfs) - 1)):
+                name = 'concat-{0}'.format(tokenize(*dfs))
+                dsk, columns = _concat_dfs(dfs, name, join=join)
+
+                divisions = []
+                for df in dfs[:-1]:
+                    # remove last to concatenate with next
+                    divisions += df.divisions[:-1]
+                divisions += dfs[-1].divisions
+
+                return_type = _get_return_type(dfs[0], columns)
+                return return_type(toolz.merge(dsk, *[df.dask for df in dfs]),
+                                   name, columns, divisions)
+            else:
+                if interleave_partitions:
+                    from .multi import concat_indexed_dataframes
+                    return concat_indexed_dataframes(dfs, join=join)
+
+                raise ValueError('All inputs have known divisions which cannnot '
+                                 'be concatenated in order. Specify '
+                                 'interleave_partitions=True to ignore order')
+
+    else:
+        if axis == 1:
+             raise ValueError('Unable to concatenate DataFrame with unknown '
+                              'division specifying axis=1')
+        else:
+            # concat will not regard Series as row
+            dfs = _maybe_from_pandas(dfs)
+            name = 'concat-{0}'.format(tokenize(*dfs))
+            dsk, columns = _concat_dfs(dfs, name, join=join)
+
+            divisions = [None] * (sum([df.npartitions for df in dfs]) + 1)
+
+            return_type = _get_return_type(dfs[0], columns)
+            return return_type(toolz.merge(dsk, *[df.dask for df in dfs]),
+                               name, columns, divisions)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -151,7 +151,7 @@ def _set_collect(group, p, barrier_token, columns):
         assert columns is not None, columns
         # when unable to get group, create dummy DataFrame
         # which has the same columns as original
-        return pd.DataFrame([], columns=columns)
+        return pd.DataFrame(columns=columns)
 
 
 def shuffle(df, index, npartitions=None):
@@ -221,7 +221,7 @@ def partition(df, index, npartitions, p):
     rng = pd.Series(np.arange(len(df)))
     if isinstance(index, Iterator):
         index = list(index)
-    if not isinstance(index, (pd.Index, pd.core.generic.NDFrame)):
+    if not isinstance(index, (pd.Index, pd.Series, pd.DataFrame)):
         index = df[index]
 
     if isinstance(index, pd.Index):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -12,7 +12,8 @@ import dask
 from dask.async import get_sync
 from dask.utils import raises, ignoring
 import dask.dataframe as dd
-from dask.dataframe.core import (concat, repartition_divisions, _loc,
+
+from dask.dataframe.core import (repartition_divisions, _loc,
         _coerce_loc_index, aca, reduction, _concat, _Frame)
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -160,3 +160,7 @@ def get_categories(df):
     if iscategorical(df.index.dtype):
         result['.index'] = df.index.categories
     return result
+
+
+def is_frame_or_series(x):
+    return isinstance(x, (pd.Series, pd.DataFrame))


### PR DESCRIPTION
2 main changes and some cleanups.

- ``_Frame.__new__`` can be called which return ``DataFrame`` or ``Series`` appropriately for internal use. ``metadata`` is corresponding to ``Series.name`` or ``DataFrame.columns``, but additionally accept data (``DataFrame`` or ``Series``) itself. It is intended to be used in ``dtype`` handling as a follow-up of #675.
- Move ``dataframe.core.concat`` to ``dataframe.multi.concat``.