### PR TITLE
Fixes for visualization file formats

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -16,14 +16,16 @@ __all__ = ("Base", "compute", "normalize_token", "tokenize", "visualize")
 class Base(object):
     """Base class for dask collections"""
 
-    def visualize(self, filename='mydask', optimize_graph=False):
-        return visualize(self, filename=filename, optimize_graph=optimize_graph)
+    def visualize(self, filename='mydask', format=None, optimize_graph=False):
+        return visualize(self, filename=filename, format=format,
+                         optimize_graph=optimize_graph)
 
-    def _visualize(self, filename='mydask', optimize_graph=False):
+    def _visualize(self, filename='mydask', format=None, optimize_graph=False):
         warn = DeprecationWarning("``_visualize`` is deprecated, use "
                                   "``visualize`` instead.")
         warnings.warn(warn)
-        return self.visualize(filename=filename, optimize_graph=optimize_graph)
+        return self.visualize(filename=filename, format=format,
+                              optimize_graph=optimize_graph)
 
     def compute(self, **kwargs):
         return compute(self, **kwargs)[0]

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -164,7 +164,7 @@ def _get_display_cls(format):
         raise ValueError("Unknown format '%s' passed to `dot_graph`" % format)
 
 
-def dot_graph(dsk, filename='mydask', format='png', **kwargs):
+def dot_graph(dsk, filename='mydask', format=None, **kwargs):
     """
     Render a task graph using dot.
 
@@ -202,6 +202,15 @@ def dot_graph(dsk, filename='mydask', format='png', **kwargs):
     dask.dot.to_graphviz
     """
     g = to_graphviz(dsk, **kwargs)
+
+    fmts = ['png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg']
+    if format is None and any(filename.lower().endswith(fmt) for fmt in fmts):
+        format = filename.lower().split('.')[-1]
+        filename = filename.rsplit('.')[0]
+
+    if format is None:
+        format = 'png'
+
     data = g.pipe(format=format)
     display_cls = _get_display_cls(format)
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -103,5 +103,7 @@ def test_visualize():
         x = da.arange(5, chunks=2)
         x.visualize(filename=os.path.join(d, 'mydask'))
         assert os.path.exists(os.path.join(d, 'mydask.png'))
+        x.visualize(filename=os.path.join(d, 'mydask.pdf'))
+        assert os.path.exists(os.path.join(d, 'mydask.pdf'))
     finally:
         shutil.rmtree(d)


### PR DESCRIPTION
1.  Pass `format=` kwarg through from `Base.visualize` to `dot_graph`
2.  Get format from filename if obvious.  E.g. `.visualize('myfile.pdf') -> format='pdf'`