### PR TITLE
Add optimization for loading index from castra

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -248,7 +248,7 @@ class _Frame(Base):
                    token='drop-duplicates')
 
     def __len__(self):
-        return reduction(self, len, np.sum, token='len').compute()
+        return reduction(self.index, len, np.sum, token='len').compute()
 
     def map_partitions(self, func, columns=no_default, *args, **kwargs):
         """ Apply Python function on each DataFrame block

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -13,8 +13,9 @@ def optimize(dsk, keys, **kwargs):
     try:
         from castra import Castra
         dsk3 = fuse_getitem(dsk2, Castra.load_partition, 3)
-        dsk4 = fuse_selections(dsk3, getattr, Castra.load_partition,
-                               lambda a, b: (Castra.load_index, b[1], b[2]))
+        def merge(a, b):
+            return (Castra.load_index, b[1], b[2]) if a[2] == 'index' else a
+        dsk4 = fuse_selections(dsk3, getattr, Castra.load_partition, merge)
     except ImportError:
         dsk4 = dsk2
     dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -5,6 +5,13 @@ from ..optimize import cull, fuse_getitem, fuse_selections
 from .. import core
 
 
+def fuse_castra_index(dsk):
+    from castra import Castra
+    def merge(a, b):
+        return (Castra.load_index, b[1], b[2]) if a[2] == 'index' else a
+    return fuse_selections(dsk, getattr, Castra.load_partition, merge)
+
+
 def optimize(dsk, keys, **kwargs):
     if isinstance(keys, list):
         dsk2 = cull(dsk, list(core.flatten(keys)))
@@ -13,9 +20,7 @@ def optimize(dsk, keys, **kwargs):
     try:
         from castra import Castra
         dsk3 = fuse_getitem(dsk2, Castra.load_partition, 3)
-        def merge(a, b):
-            return (Castra.load_index, b[1], b[2]) if a[2] == 'index' else a
-        dsk4 = fuse_selections(dsk3, getattr, Castra.load_partition, merge)
+        dsk4 = fuse_castra_index(dsk3)
     except ImportError:
         dsk4 = dsk2
     dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -1,15 +1,8 @@
 """ Dataframe optimizations """
 
-a, b, c, d, e = '~a', '~b', '~c', '~d', '~e'
-from ..rewrite import RuleSet, RewriteRule
 from .io import dataframe_from_ctable
-from ..optimize import cull, inline_functions, fuse_getitem
-from ..core import istask
-from ..utils import ignoring
+from ..optimize import cull, fuse_getitem, fuse_selections
 from .. import core
-from toolz import valmap
-from operator import getitem
-import operator
 
 
 def optimize(dsk, keys, **kwargs):
@@ -20,8 +13,10 @@ def optimize(dsk, keys, **kwargs):
     try:
         from castra import Castra
         dsk3 = fuse_getitem(dsk2, Castra.load_partition, 3)
+        dsk4 = fuse_selections(dsk3, getattr, Castra.load_partition,
+                               lambda a, b: (Castra.load_index, b[1], b[2]))
     except ImportError:
-        dsk3 = dsk2
-    dsk4 = fuse_getitem(dsk3, dataframe_from_ctable, 3)
-    dsk5 = cull(dsk4, keys)
-    return dsk5
+        dsk4 = dsk2
+    dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)
+    dsk6 = cull(dsk5, keys)
+    return dsk6

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -55,3 +55,6 @@ def test_castra_column_store():
 
         assert dsk == {(df2._name, 0): (Castra.load_partition, c, '0--2',
                                             (list, ['x']))}
+        df3 = df.index
+        dsk = dd.optimize(df3.dask, df3._keys())
+        assert dsk == {(df3._name, 0): (Castra.load_index, c, '0--2')}


### PR DESCRIPTION
This depends on https://github.com/blaze/castra/pull/53 - improves efficiency of loading just the index from a castra as well as efficiency of taking length of dataframes.