### PR TITLE
Fix series.groupby.nunique

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1817,15 +1817,14 @@ class SeriesGroupBy(_GroupBy):
                         .apply(pd.DataFrame.drop_duplicates, subset=self.key))
                 grouped.index = grouped.index.get_level_values(level=0)
             else:
-                grouped = df.groupby(index).apply(pd.Series.drop_duplicates)
-                grouped.index = index
+                grouped = pd.concat([df, index], axis=1).drop_duplicates()
             return grouped
 
         def agg(df):
-            if isinstance(df, pd.DataFrame):
-                return df.groupby(level=0)[self.key].nunique()
+            if isinstance(self.df, Series):
+                return df.groupby(df.columns[1])[df.columns[0]].nunique()
             else:
-                return df.groupby(level=0).nunique()
+                return df.groupby(level=0)[self.key].nunique()
 
         return aca([self.df, self.index],
                    chunk=chunk, aggregate=agg, columns=self.key,

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -212,7 +212,7 @@ def test_set_index():
 def test_split_apply_combine_on_series():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 6], 'b': [4, 2, 7]},
                                   index=[0, 1, 3]),
-           ('x', 1): pd.DataFrame({'a': [4, 2, 6], 'b': [3, 3, 1]},
+           ('x', 1): pd.DataFrame({'a': [4, 4, 6], 'b': [3, 3, 1]},
                                   index=[5, 6, 8]),
            ('x', 2): pd.DataFrame({'a': [4, 3, 7], 'b': [1, 1, 3]},
                                   index=[9, 9, 9])}


### PR DESCRIPTION
This follows on to #709 which passed only because the test data was trivial.

This changes the test data and fixes the uncovered issue.