### PR TITLE
Propagate exceptions without modification in async

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -565,12 +565,21 @@ class RemoteException(Exception):
         self.traceback = traceback
 
     def __str__(self):
-        return ("Remote Exception\n"
-                "----------------\n"
-                + str(self.exception) + "\n\n"
+        return (str(self.exception) + "\n\n"
                 "Traceback\n"
                 "---------\n"
                 + self.traceback)
+
+    def __dir__(self):
+        return sorted(set(dir(type(self))
+                        + list(self.__dict__)
+                        + dir(self.exception)))
+
+    def __getattr__(self, key):
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError:
+            return getattr(self.exception, key)
 
 
 exceptions = dict()

--- a/dask/async.py
+++ b/dask/async.py
@@ -488,12 +488,10 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 task = dsk[key]
                 _execute_task(task, data)  # Re-execute locally
             else:
-                raise type(res)('\nRemote Exception:\n'
-                              + '-----------------\n'
-                              + str(res) + '\n\n'
-                              + 'Traceback:\n'
-                              + '----------\n'
-                              + tb)
+                print("Traceback:\n"
+                      "----------")
+                print(tb)
+                raise(res)
         state['cache'][key] = res
         finish_task(dsk, key, state, results, keyorder.get)
         for f in posttask_cbs:

--- a/dask/async.py
+++ b/dask/async.py
@@ -488,10 +488,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 task = dsk[key]
                 _execute_task(task, data)  # Re-execute locally
             else:
-                print("Traceback:\n"
-                      "----------")
-                print(tb)
-                raise(res)
+                raise(RemoteException(res, tb))
         state['cache'][key] = res
         finish_task(dsk, key, state, results, keyorder.get)
         for f in posttask_cbs:
@@ -544,3 +541,21 @@ def sortkey(item):
     ('tuple', ('x', 1))
     """
     return (type(item).__name__, item)
+
+
+class RemoteException(Exception):
+    """ Remote Exception
+
+    Contains the exception and traceback from a remotely run task
+    """
+    def __init__(self, exception, traceback):
+        self.exception = exception
+        self.traceback = traceback
+
+    def __str__(self):
+        return ("Remote Exception\n"
+                "----------------\n"
+                + str(self.exception) + "\n\n"
+                "Traceback\n"
+                "---------\n"
+                + self.traceback)

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -148,25 +148,22 @@ def test_order_of_startstate():
     assert result['ready'] == ['b', 'y']
 
 
-def test_rerun_exceptions_locally():
-    counter = [0]
+def test_nonstandard_exceptions_propagate():
+    class MyException(Exception):
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+        def __str__(self):
+            return "My Exception!"
+
     def f():
-        counter[0] += 1
-        raise Exception('TOKEN')
+        raise MyException(1, 2)
 
     from dask.threaded import get
+
     try:
         get({'x': (f,)}, 'x')
-    except Exception as e:
-        assert 'execute_task' in str(e).lower()
-
-    try:
-        get({'x': (f,)}, 'x', rerun_exceptions_locally=True)
-    except Exception as e:
-        assert 'execute_task' not in str(e).lower()
-
-    try:
-        with dask.set_options(rerun_exceptions_locally=True):
-            get({'x': (f,)}, 'x')
-    except Exception as e:
-        assert 'execute_task' not in str(e).lower()
+        assert False
+    except MyException as e:
+        assert e.a == 1 and e.b == 2

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -168,7 +168,10 @@ def test_nonstandard_exceptions_propagate():
     except MyException as e:
         assert "My Exception!" in str(e)
         assert "Traceback" in str(e)
+        assert 'a' in dir(e)
+        assert 'traceback' in dir(e)
         assert e.exception.a == 1 and e.exception.b == 2
+        assert e.a == 1 and e.b == 2
 
 
 def test_remote_exception():

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -165,8 +165,18 @@ def test_nonstandard_exceptions_propagate():
     try:
         get({'x': (f,)}, 'x')
         assert False
-    except RemoteException as e:
-        assert isinstance(e.exception, MyException)
+    except MyException as e:
         assert "My Exception!" in str(e)
         assert "Traceback" in str(e)
         assert e.exception.a == 1 and e.exception.b == 2
+
+
+def test_remote_exception():
+    e = TypeError("hello")
+    a = remote_exception(e, 'traceback')
+    b = remote_exception(e, 'traceback')
+
+    assert type(a) == type(b)
+    assert isinstance(a, TypeError)
+    assert 'hello' in str(a)
+    assert 'traceback' in str(a)

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -165,5 +165,8 @@ def test_nonstandard_exceptions_propagate():
     try:
         get({'x': (f,)}, 'x')
         assert False
-    except MyException as e:
-        assert e.a == 1 and e.b == 2
+    except RemoteException as e:
+        assert isinstance(e.exception, MyException)
+        assert "My Exception!" in str(e)
+        assert "Traceback" in str(e)
+        assert e.exception.a == 1 and e.exception.b == 2

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -34,7 +34,6 @@ def test_errors_propagate():
         result = get(dsk, 'x')
     except Exception as e:
         assert isinstance(e, ValueError)
-        assert "bad" in str(e)
         assert "12345" in str(e)
 
 


### PR DESCRIPTION
Previously in the async scheduler we used to put the traceback into the
exception.  This caused problems because we assumed that all exceptions
expected a single message argument.  This assumption is false and,
we are unable to cleanly modify remote exceptions.

Now our policy is to print out the traceback and then raise the original
exception.

## Before

```python
In [1]: def f(x, y):
    return x / y
   ...: 

In [2]: from dask.threaded import get

In [3]: get({'x': (f, 1, 0)}, 'x')
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-3-73ec8f9d1e5e> in <module>()
----> 1 get({'x': (f, 1, 0)}, 'x')

/home/mrocklin/workspace/dask/dask/threaded.pyc in get(dsk, result, cache, num_workers, **kwargs)
     55     results = get_async(pool.apply_async, len(pool._pool), dsk, result,
     56                         cache=cache, queue=queue, get_id=_thread_get_id,
---> 57                         **kwargs)
     58 
     59     return results

/home/mrocklin/workspace/dask/dask/async.py in get_async(apply_async, num_workers, dsk, result, cache, queue, get_id, raise_on_exception, rerun_exceptions_locally, callbacks, **kwargs)
    494                               + 'Traceback:\n'
    495                               + '----------\n'
--> 496                               + tb)
    497         state['cache'][key] = res
    498         finish_task(dsk, key, state, results, keyorder.get)

ZeroDivisionError: 
Remote Exception:
-----------------
integer division or modulo by zero

Traceback:
----------
  File "dask/async.py", line 266, in execute_task
    result = _execute_task(task, data)
  File "dask/async.py", line 249, in _execute_task
    return func(*args2)
  File "<ipython-input-1-9a7ad601d93b>", line 2, in f
    return x / y
```

## After

```python
In [1]: def f(x, y):
    return x / y
   ...: 

In [2]: from dask.threaded import get

In [3]: get({'x': (f, 1, 0)}, 'x')
Traceback:
----------
  File "dask/async.py", line 266, in execute_task
    result = _execute_task(task, data)
  File "dask/async.py", line 249, in _execute_task
    return func(*args2)
  File "<ipython-input-1-9a7ad601d93b>", line 2, in f
    return x / y

---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-3-73ec8f9d1e5e> in <module>()
----> 1 get({'x': (f, 1, 0)}, 'x')

/home/mrocklin/workspace/dask/dask/threaded.pyc in get(dsk, result, cache, num_workers, **kwargs)
     55     results = get_async(pool.apply_async, len(pool._pool), dsk, result,
     56                         cache=cache, queue=queue, get_id=_thread_get_id,
---> 57                         **kwargs)
     58 
     59     return results

/home/mrocklin/workspace/dask/dask/async.py in get_async(apply_async, num_workers, dsk, result, cache, queue, get_id, raise_on_exception, rerun_exceptions_locally, callbacks, **kwargs)
    492                       "----------")
    493                 print(tb)
--> 494                 raise(res)
    495         state['cache'][key] = res
    496         finish_task(dsk, key, state, results, keyorder.get)

ZeroDivisionError: integer division or modulo by zero
```