### PR TITLE
WIP fixes to textblock and read_csv encodings

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -17,7 +17,7 @@ def test_textblock():
             assert textblock(f, 1, 10) == textblock(fn, 1, 10)
 
             assert textblock(f, 0, 3) == ('123' + os.linesep).encode()
-            assert textblock(f, 3 + len(os.linesep), 6) == ('456' + os.linesep).encode()
+            assert textblock(f, 3, 3) == b''
 
 
 def test_takes_multiple_arguments():

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -1,6 +1,8 @@
 import os
 
-from dask.utils import textblock, filetext, takes_multiple_arguments, Dispatch
+from dask.utils import (textblock, filetext, takes_multiple_arguments,
+                        Dispatch, tmpfile, next_newline)
+
 
 def test_textblock():
     text = b'123 456 789 abc def ghi'.replace(b' ', os.linesep.encode())
@@ -50,3 +52,54 @@ def test_dispatch():
     assert foo(1.0) == 0.0
     assert foo(b) == b
     assert foo((1, 2.0, b)) == (2, 1.0, b)
+
+
+def test_nextnewline():
+    encoding = 'utf-16-le'
+
+    euro = u'\u20ac'
+    yen = u'\u00a5'
+
+    bin_euro = u'\u20ac'.encode(encoding)
+    bin_yen = u'\u00a5'.encode(encoding)
+    bin_newline = '\n'.encode(encoding)
+
+    data = (euro * 10) + '\n' + (yen * 10) + '\n' + (euro * 10)
+    bin_data = data.encode(encoding)
+
+    with tmpfile() as fn:
+        with open(fn, 'w+b') as f:
+            f.write(bin_data)
+            f.seek(0)
+
+            start, stop = next_newline(f, 2, encoding)
+            assert start == len(bin_euro) * 10
+            assert stop == len(bin_euro) * 10 + len('\n'.encode(encoding))
+
+            start, stop = next_newline(f, len(bin_euro)*11, encoding)
+            assert start == len(bin_euro) * 20 + len(bin_newline)
+            assert stop == len(bin_euro) * 20 + len(bin_newline) * 2
+
+
+def test_gh606():
+    encoding = 'utf-16-le'
+    euro = u'\u20ac'
+    yen = u'\u00a5'
+    bin_euro = u'\u20ac'.encode(encoding)
+    bin_yen = u'\u00a5'.encode(encoding)
+
+    data = (euro * 10) + '\n' + (yen * 10) + '\n' + (euro * 10)
+    bin_data = data.encode(encoding)
+
+    with tmpfile() as fn:
+        with open(fn, 'w+b') as f:
+            f.write(bin_data)
+            f.seek(0)
+
+            stop = len(bin_euro) * 10 + len('\n'.encode(encoding))
+            res = textblock(f, 1, stop, encoding=encoding)
+            assert res == ((yen * 10) + '\n').encode(encoding)
+
+            stop = len(bin_euro) * 10 + len('\n'.encode(encoding))
+            res = textblock(f, 0, stop, encoding=encoding)
+            assert res == ((euro * 10) + '\n' + (yen * 10) + '\n').encode(encoding)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -136,12 +136,12 @@ def filetexts(d, open=open):
 opens = {'gzip': gzip.open}
 
 
-def next_newline(fo, seek, encoding):
-    bin_newline = '\n'.encode(encoding)
+def next_linesep(fo, seek, encoding, linesep):
+    bin_linesep = linesep.encode(encoding)
     data = b''
     data_len = 0
 
-    while bin_newline not in data:
+    while bin_linesep not in data:
         data_len += 1
         fo.seek(seek)
         data = fo.read(data_len)
@@ -149,14 +149,15 @@ def next_newline(fo, seek, encoding):
             break  # eof
 
     stop = seek + data_len
-    start = stop - len(bin_newline)
+    start = stop - len(bin_linesep)
     return start, stop
 
 
-def textblock(file, start, stop, compression=None, encoding=None):
+def textblock(file, start, stop, compression=None, encoding=None,
+              linesep=None):
     """ Pull out a block of text from a file given start and stop bytes
 
-    This gets data starting/ending from the next newline delimiter
+    This gets data starting/ending from the next linesep delimiter
 
     Example
     -------
@@ -185,8 +186,11 @@ def textblock(file, start, stop, compression=None, encoding=None):
         if encoding is None:
             encoding = 'utf-8'
 
+    if linesep is None:
+        linesep = os.linesep
+
     if start:
-        startstart, startstop = next_newline(file, start, encoding)
+        startstart, startstop = next_linesep(file, start, encoding, linesep)
     else:
         startstart = start
         startstop = start
@@ -195,7 +199,7 @@ def textblock(file, start, stop, compression=None, encoding=None):
         file.seek(start)
         return file.read()
 
-    stopstart, stopstop = next_newline(file, stop, encoding)
+    stopstart, stopstop = next_linesep(file, stop, encoding, linesep)
 
     file.seek(startstop)
 


### PR DESCRIPTION
This fixes the textblock issues brought up in #606 

However it does not fix the test case @mrocklin posted:
```python
def test_encoding_gh601():
    with tmpfile('.csv') as fn:
        ar = pd.Series(range(0, 100))
        br = ar % 7
        cr = br * 3.3
        dr = br / 1.9836
        test_df = pd.concat([ar, br, cr, dr], axis=1)
        test_df.to_csv(fn, encoding='utf-16')

        d = dd.read_csv(fn, encoding='utf-16', chunkbytes=1000)

        d.count().compute(get=get_sync)
```
This is because `utf-16` leaves the byte order ambiguous. You can specify `utf-16-le` or `utf-16-ge` to make this work.

When you use `utf-16` in pandas and it will check the Byte Order Mark (BOM) at the beginning of the file to figure out the endianness. But dask is splitting up the file, and handing pieces to `pd.read_csv` without a BOM. So it fails.

I can fix this, or we can just say "specify the byte ordering".