### PR TITLE
Add error for using `set_index` in read_csv

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -91,6 +91,14 @@ def fill_kwargs(fn, args, kwargs):
     kwargs: dict
         keyword arguments to give to pd.read_csv
     """
+
+    if 'index_col' in kwargs:
+        msg = """
+        The index column cannot be set at dataframe creation time. Instead use
+        the `set_index` method on the dataframe after it is created.
+        """
+        raise ValueError(msg)
+
     kwargs = merge(csv_defaults, kwargs)
     sample_nrows = kwargs.pop('sample_nrows', 1000)
     essentials = ['columns', 'names', 'header', 'parse_dates', 'dtype']

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -712,3 +712,12 @@ def test_hdf_globbing():
         tm.assert_frame_equal(res.compute(), pd.concat([df] *  3))
     finally:
         shutil.rmtree(tdir)
+
+
+def test_index_col():
+    with filetext(text) as fn:
+        try:
+            f = read_csv(fn, chunkbytes=30, index_col='name')
+            assert False
+        except ValueError as e:
+            assert 'set_index' in str(e)


### PR DESCRIPTION
closes #714 

I didn't add a test, but verified that this works locally. I can add one, but I wasn't sure if this needed one.