### PR TITLE
Add DataFrame.where and mask

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -691,6 +691,16 @@ class _Frame(Base):
         return self._cum_agg('cummin', self._partition_type.cummin,
                              aggregate, np.nan, axis=axis)
 
+    @wraps(pd.DataFrame.where)
+    def where(self, cond, other=np.nan):
+        return map_partitions(self._partition_type.where,
+                              self.column_info, self, cond, other)
+
+    @wraps(pd.DataFrame.mask)
+    def mask(self, cond, other=np.nan):
+        return map_partitions(self._partition_type.mask,
+                              self.column_info, self, cond, other)
+
     @classmethod
     def _bind_operator_method(cls, name, op):
         """ bind operator method like DataFrame.add to this class """


### PR DESCRIPTION
Related to #653. Can this close it?

```
import pandas as pd
import dask.dataframe as dd

df1 = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
df2 = pd.DataFrame([[True, False, False],
                    [False, True, False],
                    [False, False, True]])
ddf1 = dd.from_pandas(df1, 2)
ddf2 = dd.from_pandas(df2, 2)

ddf1.where(ddf2).compute()
#     0   1   2
# 0   1 NaN NaN
# 1 NaN   5 NaN
# 2 NaN NaN   9

ddf1.where(ddf2, -ddf1).compute()
#    0  1  2
# 0  1 -2 -3
# 1 -4  5 -6
# 2 -7 -8  9

# mask is a inverse op of where
ddf1.mask(ddf2).compute()
#     0   1   2
# 0 NaN   2   3
# 1   4 NaN   6
# 2   7   8 NaN

ddf1.mask(ddf2, -ddf1).compute()
#    0  1  2
# 0 -1  2  3
# 1  4 -5  6
# 2  7  8 -9
```