### PR TITLE
CLN/DOC: Add decorator to handle docstrings more properly

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -4,12 +4,11 @@ from __future__ import absolute_import, division, print_function
 
 from collections import Container, Iterable, Sequence
 from functools import wraps
-from inspect import getargspec
 
 from toolz import concat
 import numpy as np
 
-from ..compatibility import builtins
+from ..compatibility import builtins, getargspec
 from ..utils import ignoring
 
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -25,7 +25,7 @@ from . import numpy_compat
 from ..base import Base, compute, tokenize, normalize_token
 from ..utils import (deepmap, ignoring, repr_long_list, concrete, is_integer,
         IndexCallable)
-from ..compatibility import unicode, long
+from ..compatibility import unicode, long, getargspec
 from .. import threaded, core
 
 
@@ -451,7 +451,7 @@ def map_blocks(func, *arrs, **kwargs):
     # If func has block_id as an argument then swap out func
     # for func with block_id partialed in
     try:
-        spec = inspect.getargspec(func)
+        spec = getargspec(func)
     except:
         spec = None
     if spec and 'block_id' in spec.args:

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -10,7 +10,8 @@ from .slicing import insert_many
 from .numpy_compat import divide
 from ..core import flatten
 from . import chunk
-from ..utils import ignoring, getargspec
+from ..compatibility import getargspec
+from ..utils import ignoring
 
 
 def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None):

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import functools
+import inspect
 import operator
 import sys
 import types
@@ -25,6 +27,9 @@ if PY3:
     range = range
     operator_div = operator.truediv
 
+    def _getargspec(func):
+        return inspect.getfullargspec(func)
+
 else:
     import __builtin__ as builtins
     from Queue import Queue, Empty
@@ -39,6 +44,20 @@ else:
     apply = apply
     range = xrange
     operator_div = operator.div
+
+    def _getargspec(func):
+        return inspect.getargspec(func)
+
+
+def getargspec(func):
+    """Version of inspect.getargspec that works for functools.partial objects"""
+    if isinstance(func, functools.partial):
+        return _getargspec(func.func)
+    else:
+        if isinstance(func, type):
+            return _getargspec(func.__init__)
+        else:
+            return _getargspec(func)
 
 def skip(func):
     return

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -240,12 +240,6 @@ class _Frame(Base):
                     for i, key in enumerate(self._keys()))
         return self._constructor(dsk2, name, self.column_info, self.divisions)
 
-    @derived_from(pd.DataFrame, version='0.17.0')
-    def xxx(self):
-        chunk = lambda s: s.drop_duplicates()
-        return aca(self, chunk=chunk, aggregate=chunk, columns=self.column_info,
-                   token='drop-duplicates')
-
     @derived_from(pd.DataFrame)
     def drop_duplicates(self):
         chunk = lambda s: s.drop_duplicates()
@@ -263,19 +257,26 @@ class _Frame(Base):
         result is a Series).  The output type will be determined by the type of
         ``columns``.
 
-        >>> df.map_partitions(lambda df: df.x + 1, columns='x')  # doctest: +SKIP
-
-        >>> df.map_partitions(lambda df: df.head(), columns=df.columns)  # doctest: +SKIP
-
         Parameters
         ----------
 
-        func: function
+        func : function
             Function applied to each blocks
-        columns: tuple or scalar
+        columns : tuple or scalar
             Column names or name of the output. Defaults to names of data itself.
             When tuple is passed, DataFrame is returned. When scalar is passed,
             Series is returned.
+
+        Examples
+        --------
+
+        When str is passed as columns, the result will be Series.
+
+        >>> df.map_partitions(lambda df: df.x + 1, columns='x')  # doctest: +SKIP
+
+        When tuple is passed as columns, the result will be Series.
+
+        >>> df.map_partitions(lambda df: df.head(), columns=df.columns)  # doctest: +SKIP
         """
         if columns == no_default:
             columns = self.column_info
@@ -284,10 +285,15 @@ class _Frame(Base):
     def random_split(self, p, seed=None):
         """ Pseudorandomly split dataframe into different pieces row-wise
 
+        Examples
+        --------
+
         50/50 split
+
         >>> a, b = df.random_split([0.5, 0.5])  # doctest: +SKIP
 
         80/10/10 split, consistent seed
+
         >>> a, b, c = df.random_split([0.8, 0.1, 0.1], seed=123)  # doctest: +SKIP
         """
         seeds = np.random.RandomState(seed).randint(0, np.iinfo(np.int32).max,
@@ -423,12 +429,15 @@ class _Frame(Base):
         Parameters
         ----------
 
-        divisions: list
+        divisions : list
             List of partitions to be used
-        force: bool, default False
+        force : bool, default False
             Allows the expansion of the existing divisions.
             If False then the new divisions lower and upper bounds must be
             the same as the old divisions.
+
+        Examples
+        --------
 
         >>> df = df.repartition([0, 5, 10, 20])  # doctest: +SKIP
         """
@@ -598,6 +607,9 @@ class _Frame(Base):
 
     def quantile(self, q=0.5, axis=0):
         """ Approximate row-wise and precise column-wise quantiles of DataFrame
+
+        Parameters
+        ----------
 
         q : list/array of floats, default 0.5 (50%)
             Iterable of numbers ranging from 0 to 1 for the desired quantiles
@@ -1975,9 +1987,12 @@ def _get_return_type(arg, columns):
 def map_partitions(func, columns, *args, **kwargs):
     """ Apply Python function on each DataFrame block
 
-    column_info: tuple or string
+    Parameters
+    ----------
+
+    column_info : tuple or string
         Column names or name of the output
-    targets: list
+    targets : list
         List of target DataFrame / Series.
     """
     assert callable(func)
@@ -2175,20 +2190,25 @@ def repartition_divisions(a, b, name, out1, out2, force=False):
 
     Parameters
     ----------
-    a: tuple
+
+    a : tuple
         old divisions
-    b: tuple, list
+    b : tuple, list
         new divisions
-    name: str
+    name : str
         name of old dataframe
-    out1: str
+    out1 : str
         name of temporary splits
-    out2: str
+    out2 : str
         name of new dataframe
-    force: bool, default False
+    force : bool, default False
         Allows the expansion of the existing divisions.
         If False then the new divisions lower and upper bounds must be
         the same as the old divisions.
+
+
+    Examples
+    --------
 
     >>> repartition_divisions([1, 3, 7], [1, 4, 6, 7], 'a', 'b', 'c')  # doctest: +SKIP
     {('b', 0): (<function _loc at ...>, ('a', 0), 1, 3, False),
@@ -2329,12 +2349,16 @@ def repartition(df, divisions, force=False):
     Parameters
     ----------
 
-    divisions: list
+    divisions : list
         List of partitions to be used
-    force: bool, default False
+    force : bool, default False
         Allows the expansion of the existing divisions.
         If False then the new divisions lower and upper bounds must be
         the same as the old divisions.
+
+
+    Examples
+    --------
 
     >>> df = df.repartition([0, 5, 10, 20])  # doctest: +SKIP
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4,7 +4,6 @@ import bisect
 from collections import Iterable, Iterator
 from datetime import datetime
 from distutils.version import LooseVersion
-from functools import wraps
 import operator
 from operator import getitem, setitem
 from pprint import pformat
@@ -25,8 +24,8 @@ from .. import core
 from ..array.core import partial_by_order
 from .. import threaded
 from ..compatibility import unicode, apply, operator_div, bind_method
-from ..utils import repr_long_list, IndexCallable, pseudorandom
-from . import utils
+from ..utils import (repr_long_list, IndexCallable,
+                     pseudorandom, derived_from)
 from ..base import Base, compute, tokenize, normalize_token
 
 no_default = '__no_default__'
@@ -241,7 +240,13 @@ class _Frame(Base):
                     for i, key in enumerate(self._keys()))
         return self._constructor(dsk2, name, self.column_info, self.divisions)
 
-    @wraps(pd.DataFrame.drop_duplicates)
+    @derived_from(pd.DataFrame, version='0.17.0')
+    def xxx(self):
+        chunk = lambda s: s.drop_duplicates()
+        return aca(self, chunk=chunk, aggregate=chunk, columns=self.column_info,
+                   token='drop-duplicates')
+
+    @derived_from(pd.DataFrame)
     def drop_duplicates(self):
         chunk = lambda s: s.drop_duplicates()
         return aca(self, chunk=chunk, aggregate=chunk, columns=self.column_info,
@@ -435,7 +440,7 @@ class _Frame(Base):
     def __setstate__(self, dict):
         self.__dict__ = dict
 
-    @wraps(pd.Series.fillna)
+    @derived_from(pd.Series)
     def fillna(self, value):
         func = getattr(self._partition_type, 'fillna')
         return map_partitions(func, self.column_info, self, value)
@@ -467,14 +472,14 @@ class _Frame(Base):
         return self._constructor(merge(self.dask, dsk), name,
                                        self.column_info, self.divisions)
 
-    @wraps(pd.DataFrame.to_hdf)
+    @derived_from(pd.DataFrame)
     def to_hdf(self, path_or_buf, key, mode='a', append=False, complevel=0,
                complib=None, fletcher32=False, **kwargs):
         from .io import to_hdf
         return to_hdf(self, path_or_buf, key, mode, append, complevel, complib,
                 fletcher32, **kwargs)
 
-    @wraps(pd.DataFrame.to_csv)
+    @derived_from(pd.DataFrame)
     def to_csv(self, filename, **kwargs):
         from .io import to_csv
         return to_csv(self, filename, **kwargs)
@@ -494,7 +499,7 @@ class _Frame(Base):
         """ Wrapper for aggregations """
         raise NotImplementedError
 
-    @wraps(pd.DataFrame.sum)
+    @derived_from(pd.DataFrame)
     def sum(self, axis=None):
         axis = self._validate_axis(axis)
         if axis == 1:
@@ -504,7 +509,7 @@ class _Frame(Base):
         else:
             return self._aca_agg(token='sum', func=lambda x: x.sum())
 
-    @wraps(pd.DataFrame.max)
+    @derived_from(pd.DataFrame)
     def max(self, axis=None):
         axis = self._validate_axis(axis)
         if axis == 1:
@@ -514,7 +519,7 @@ class _Frame(Base):
         else:
             return self._aca_agg(token='max', func=lambda x: x.max())
 
-    @wraps(pd.DataFrame.min)
+    @derived_from(pd.DataFrame)
     def min(self, axis=None):
         axis = self._validate_axis(axis)
         if axis == 1:
@@ -524,7 +529,7 @@ class _Frame(Base):
         else:
             return self._aca_agg(token='min', func=lambda x: x.min())
 
-    @wraps(pd.DataFrame.count)
+    @derived_from(pd.DataFrame)
     def count(self, axis=None):
         axis = self._validate_axis(axis)
         if axis == 1:
@@ -535,7 +540,7 @@ class _Frame(Base):
             return self._aca_agg(token='count', func=lambda x: x.count(),
                                  aggfunc=lambda x: x.sum())
 
-    @wraps(pd.DataFrame.mean)
+    @derived_from(pd.DataFrame)
     def mean(self, axis=None):
         axis = self._validate_axis(axis)
         if axis == 1:
@@ -555,7 +560,7 @@ class _Frame(Base):
             name = '{0}mean-{1}'.format(self._token_prefix, tokenize(s))
             return map_partitions(f, no_default, s, n, token=name)
 
-    @wraps(pd.DataFrame.var)
+    @derived_from(pd.DataFrame)
     def var(self, axis=None, ddof=1):
         axis = self._validate_axis(axis)
         if axis == 1:
@@ -579,7 +584,7 @@ class _Frame(Base):
             name = '{0}var(ddof={1})'.format(self._token_prefix, ddof)
             return map_partitions(f, no_default, x2, x, n, token=name)
 
-    @wraps(pd.DataFrame.std)
+    @derived_from(pd.DataFrame)
     def std(self, axis=None, ddof=1):
         axis = self._validate_axis(axis)
         if axis == 1:
@@ -626,7 +631,7 @@ class _Frame(Base):
                 return DataFrame(dask, name, num.columns,
                                  quantiles[0].divisions)
 
-    @wraps(pd.DataFrame.describe)
+    @derived_from(pd.DataFrame)
     def describe(self):
         name = 'describe--' + tokenize(self)
 
@@ -688,17 +693,17 @@ class _Frame(Base):
             return self._constructor(merge(dask, cumpart.dask, cumlast.dask),
                                      name, self.column_info, self.divisions)
 
-    @wraps(pd.DataFrame.cumsum)
+    @derived_from(pd.DataFrame)
     def cumsum(self, axis=None):
         return self._cum_agg('cumsum', self._partition_type.cumsum,
                              operator.add, 0, axis=axis)
 
-    @wraps(pd.DataFrame.cumprod)
+    @derived_from(pd.DataFrame)
     def cumprod(self, axis=None):
         return self._cum_agg('cumprod', self._partition_type.cumprod,
                              operator.mul, 1, axis=axis)
 
-    @wraps(pd.DataFrame.cummax)
+    @derived_from(pd.DataFrame)
     def cummax(self, axis=None):
         def aggregate(x, y):
             if isinstance(x, (pd.Series, pd.DataFrame)):
@@ -708,7 +713,7 @@ class _Frame(Base):
         return self._cum_agg('cummax', self._partition_type.cummax,
                              aggregate, np.nan, axis=axis)
 
-    @wraps(pd.DataFrame.cummin)
+    @derived_from(pd.DataFrame)
     def cummin(self, axis=None):
         def aggregate(x, y):
             if isinstance(x, (pd.Series, pd.DataFrame)):
@@ -718,12 +723,12 @@ class _Frame(Base):
         return self._cum_agg('cummin', self._partition_type.cummin,
                              aggregate, np.nan, axis=axis)
 
-    @wraps(pd.DataFrame.where)
+    @derived_from(pd.DataFrame)
     def where(self, cond, other=np.nan):
         return map_partitions(self._partition_type.where,
                               self.column_info, self, cond, other)
 
-    @wraps(pd.DataFrame.mask)
+    @derived_from(pd.DataFrame)
     def mask(self, cond, other=np.nan):
         return map_partitions(self._partition_type.mask,
                               self.column_info, self, cond, other)
@@ -918,7 +923,7 @@ class Series(_Frame):
                           self.name, self.divisions)
         raise NotImplementedError()
 
-    @wraps(pd.DataFrame._get_numeric_data)
+    @derived_from(pd.DataFrame)
     def _get_numeric_data(self, how='any', subset=None):
         return self
 
@@ -938,59 +943,59 @@ class Series(_Frame):
                    aggregate=lambda x: aggfunc(pd.Series(x)),
                    columns=return_scalar, token=self._token_prefix + token)
 
-    @wraps(pd.Series.groupby)
+    @derived_from(pd.Series)
     def groupby(self, index, **kwargs):
         return SeriesGroupBy(self, index, **kwargs)
 
-    @wraps(pd.Series.sum)
+    @derived_from(pd.Series)
     def sum(self, axis=None):
         return super(Series, self).sum(axis=axis)
 
-    @wraps(pd.Series.max)
+    @derived_from(pd.Series)
     def max(self, axis=None):
         return super(Series, self).max(axis=axis)
 
-    @wraps(pd.Series.min)
+    @derived_from(pd.Series)
     def min(self, axis=None):
         return super(Series, self).min(axis=axis)
 
-    @wraps(pd.Series.count)
+    @derived_from(pd.Series)
     def count(self):
         return super(Series, self).count()
 
-    @wraps(pd.Series.mean)
+    @derived_from(pd.Series)
     def mean(self, axis=None):
         return super(Series, self).mean(axis=axis)
 
-    @wraps(pd.Series.var)
+    @derived_from(pd.Series)
     def var(self, axis=None, ddof=1):
         return super(Series, self).var(axis=axis, ddof=ddof)
 
-    @wraps(pd.Series.std)
+    @derived_from(pd.Series)
     def std(self, axis=None, ddof=1):
         return super(Series, self).std(axis=axis, ddof=ddof)
 
-    @wraps(pd.Series.cumsum)
+    @derived_from(pd.Series)
     def cumsum(self, axis=None):
         return super(Series, self).cumsum(axis=axis)
 
-    @wraps(pd.Series.cumprod)
+    @derived_from(pd.Series)
     def cumprod(self, axis=None):
         return super(Series, self).cumprod(axis=axis)
 
-    @wraps(pd.Series.cummax)
+    @derived_from(pd.Series)
     def cummax(self, axis=None):
         return super(Series, self).cummax(axis=axis)
 
-    @wraps(pd.Series.cummin)
+    @derived_from(pd.Series)
     def cummin(self, axis=None):
         return super(Series, self).cummin(axis=axis)
 
-    @wraps(pd.Series.nunique)
+    @derived_from(pd.Series)
     def nunique(self):
         return self.drop_duplicates().count()
 
-    @wraps(pd.Series.value_counts)
+    @derived_from(pd.Series)
     def value_counts(self):
         chunk = lambda s: s.value_counts()
         if LooseVersion(pd.__version__) > '0.16.2':
@@ -1000,36 +1005,36 @@ class Series(_Frame):
         return aca(self, chunk=chunk, aggregate=agg, columns=self.name,
                    token='value-counts')
 
-    @wraps(pd.Series.nlargest)
+    @derived_from(pd.Series)
     def nlargest(self, n=5):
         return nlargest(self, n)
 
-    @wraps(pd.Series.isin)
+    @derived_from(pd.Series)
     def isin(self, other):
         return elemwise(pd.Series.isin, self, other)
 
-    @wraps(pd.Series.map)
+    @derived_from(pd.Series)
     def map(self, arg, na_action=None):
         return elemwise(pd.Series.map, self, arg, na_action, name=self.name)
 
-    @wraps(pd.Series.astype)
+    @derived_from(pd.Series)
     def astype(self, dtype):
         return map_partitions(pd.Series.astype, self.name, self, dtype)
 
-    @wraps(pd.Series.dropna)
+    @derived_from(pd.Series)
     def dropna(self):
         return map_partitions(pd.Series.dropna, self.name, self)
 
-    @wraps(pd.Series.between)
+    @derived_from(pd.Series)
     def between(self, left, right, inclusive=True):
         return map_partitions(pd.Series.between, self.name, self, left, right,
                 inclusive)
 
-    @wraps(pd.Series.clip)
+    @derived_from(pd.Series)
     def clip(self, lower=None, upper=None):
         return map_partitions(pd.Series.clip, self.name, self, lower, upper)
 
-    @wraps(pd.Series.notnull)
+    @derived_from(pd.Series)
     def notnull(self):
         return map_partitions(pd.Series.notnull, self.name, self)
 
@@ -1045,7 +1050,7 @@ class Series(_Frame):
         from .io import to_bag
         return to_bag(self, index)
 
-    @wraps(pd.Series.to_frame)
+    @derived_from(pd.Series)
     def to_frame(self, name=None):
         _name = name if name is not None else self.name
         return map_partitions(pd.Series.to_frame, [_name], self, name)
@@ -1203,7 +1208,7 @@ class DataFrame(_Frame):
         """ Return data types """
         return self._dtypes
 
-    @wraps(pd.DataFrame.set_index)
+    @derived_from(pd.DataFrame)
     def set_index(self, other, **kwargs):
         from .shuffle import set_index
         return set_index(self, other, **kwargs)
@@ -1224,21 +1229,18 @@ class DataFrame(_Frame):
         """ Return DataFrame.columns """
         return self.columns
 
+    @derived_from(pd.DataFrame)
     def nlargest(self, n=5, columns=None):
-        """
-        Return the rows which contain the largest n elements from the provided
-        column, in descending order.
-        """
         return nlargest(self, n, columns)
 
-    @wraps(pd.DataFrame.groupby)
+    @derived_from(pd.DataFrame)
     def groupby(self, key, **kwargs):
         return GroupBy(self, key, **kwargs)
 
     def categorize(self, columns=None, **kwargs):
         return categorize(self, columns, **kwargs)
 
-    @wraps(pd.DataFrame.assign)
+    @derived_from(pd.DataFrame)
     def assign(self, **kwargs):
         pairs = list(sum(kwargs.items(), ()))
 
@@ -1246,7 +1248,7 @@ class DataFrame(_Frame):
         df2 = self._empty_partition.assign(**dict((k, []) for k in kwargs))
         return elemwise(_assign, self, *pairs, columns=list(df2.columns))
 
-    @wraps(pd.DataFrame.rename)
+    @derived_from(pd.DataFrame)
     def rename(self, index=None, columns=None):
         if index is not None:
             raise ValueError("Cannot rename index.")
@@ -1281,7 +1283,7 @@ class DataFrame(_Frame):
         return self._constructor(merge(dsk, self.dask), name,
                                        self.columns, self.divisions)
 
-    @wraps(pd.DataFrame.dropna)
+    @derived_from(pd.DataFrame)
     def dropna(self, how='any', subset=None):
         def f(df, how=how, subset=subset):
             return df.dropna(how=how, subset=subset)
@@ -1312,7 +1314,12 @@ class DataFrame(_Frame):
         from .io import to_bag
         return to_bag(self, index)
 
-    @wraps(pd.DataFrame._get_numeric_data)
+    @cache_readonly
+    def _numeric_columns(self):
+        # Cache to avoid repeated calls
+        dummy = self._get(self.dask, self._keys()[0])._get_numeric_data()
+        return dummy.columns.tolist()
+
     def _get_numeric_data(self, how='any', subset=None):
         numeric_columns = [c for c, dtype in zip(self.columns, self.dtypes)
                            if issubclass(dtype.type, np.number)]
@@ -1341,7 +1348,7 @@ class DataFrame(_Frame):
                    aggregate=lambda x: aggfunc(x.groupby(level=0)),
                    columns=None, token=self._token_prefix + token)
 
-    @wraps(pd.DataFrame.drop)
+    @derived_from(pd.DataFrame)
     def drop(self, labels, axis=0):
         if axis != 1:
             raise NotImplementedError("Drop currently only works for axis=1")
@@ -1349,7 +1356,7 @@ class DataFrame(_Frame):
         columns = list(self._empty_partition.drop(labels, axis=axis).columns)
         return elemwise(pd.DataFrame.drop, self, labels, axis, columns=columns)
 
-    @wraps(pd.DataFrame.merge)
+    @derived_from(pd.DataFrame)
     def merge(self, right, how='inner', on=None, left_on=None, right_on=None,
               left_index=False, right_index=False,
               suffixes=('_x', '_y'), npartitions=None):
@@ -1363,7 +1370,7 @@ class DataFrame(_Frame):
                      left_index=left_index, right_index=right_index,
                      suffixes=suffixes, npartitions=npartitions)
 
-    @wraps(pd.DataFrame.join)
+    @derived_from(pd.DataFrame)
     def join(self, other, on=None, how='left',
              lsuffix='', rsuffix='', npartitions=None):
 
@@ -1708,27 +1715,28 @@ class _GroupBy(object):
             return aca(self.df, chunk=chunk, aggregate=agg,
                        columns=self.key, token=token)
 
-    @wraps(pd.core.groupby.GroupBy.sum)
+    @derived_from(pd.core.groupby.GroupBy)
     def sum(self):
         return self._aca_agg(token='sum', func=lambda x: x.sum())
 
-    @wraps(pd.core.groupby.GroupBy.min)
+    @derived_from(pd.core.groupby.GroupBy)
     def min(self):
         return self._aca_agg(token='min', func=lambda x: x.min())
 
-    @wraps(pd.core.groupby.GroupBy.max)
+    @derived_from(pd.core.groupby.GroupBy)
     def max(self):
         return self._aca_agg(token='max', func=lambda x: x.max())
 
-    @wraps(pd.core.groupby.GroupBy.count)
+    @derived_from(pd.core.groupby.GroupBy)
     def count(self):
         return self._aca_agg(token='count', func=lambda x: x.count(),
                              aggfunc=lambda x: x.sum())
 
-    @wraps(pd.core.groupby.GroupBy.mean)
+    @derived_from(pd.core.groupby.GroupBy)
     def mean(self):
         return 1.0 * self.sum() / self.count()
 
+    @derived_from(pd.core.groupby.GroupBy)
     def get_group(self, key):
         token = self._token_prefix + 'get_group'
         return map_partitions(_groupby_get_group, self.column_info,
@@ -2344,7 +2352,8 @@ def repartition(df, divisions, force=False):
                                df.column_info, divisions)
     elif isinstance(df, (pd.Series, pd.DataFrame)):
         name = 'repartition-dataframe-' + token
-        dfs = utils.shard_df_on_index(df, divisions[1:-1])
+        from .utils import shard_df_on_index
+        dfs = shard_df_on_index(df, divisions[1:-1])
         dsk = dict(((name, i), df) for i, df in enumerate(dfs))
         return _Frame(dsk, name, df, divisions)
     raise ValueError('Data must be DataFrame or Series')

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -437,32 +437,38 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
     """ Concatenate DataFrames along rows.
 
     - When axis=0 (default), concatenate DataFrames row-wise:
+
       - If all divisions are known and ordered, concatenate DataFrames keeping
         divisions. When divisions are not ordered, specifying
         interleave_partition=True allows concatenate divisions each by each.
+
       - If any of division is unknown, concatenate DataFrames resetting its
         division to unknown (None)
+
     - When axis=1, concatenate DataFrames column-wise:
+
       - Allowed if all divisions are known.
+
       - If any of division is unknown, it raises ValueError.
 
     Parameters
     ----------
 
-    dfs: list
+    dfs : list
         List of dask.DataFrames to be concatenated
-    axis: {0, 1, 'index', 'columns'}, default 0
+    axis : {0, 1, 'index', 'columns'}, default 0
         The axis to concatenate along
     join : {'inner', 'outer'}, default 'outer'
         How to handle indexes on other axis
-    interleave_partitions: bool, default False
+    interleave_partitions : bool, default False
         Whether to concatenate DataFrames ignoring its order. If True, every
         divisions are concatenated each by each.
 
     Examples
     --------
 
-    # If all divisions are known and ordered, divisions are kept.
+    If all divisions are known and ordered, divisions are kept.
+
     >>> a                                               # doctest: +SKIP
     dd.DataFrame<x, divisions=(1, 3, 5)>
     >>> b                                               # doctest: +SKIP
@@ -470,7 +476,8 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
     >>> dd.concat([a, b])                               # doctest: +SKIP
     dd.DataFrame<concat-..., divisions=(1, 3, 6, 8, 10)>
 
-    # Unable to concatenate if divisions are not ordered.
+    Unable to concatenate if divisions are not ordered.
+
     >>> a                                               # doctest: +SKIP
     dd.DataFrame<x, divisions=(1, 3, 5)>
     >>> b                                               # doctest: +SKIP
@@ -479,11 +486,13 @@ def concat(dfs, axis=0, join='outer', interleave_partitions=False):
     ValueError: All inputs have known divisions which cannnot be concatenated
     in order. Specify interleave_partitions=True to ignore order
 
-    # Specify interleave_partitions=True to ignore the division order.
+    Specify interleave_partitions=True to ignore the division order.
+
     >>> dd.concat([a, b], interleave_partitions=True)   # doctest: +SKIP
     dd.DataFrame<concat-..., divisions=(1, 2, 3, 5, 6)>
 
-    # If any of division is unknown, the result division will be unknown
+    If any of division is unknown, the result division will be unknown
+
     >>> a                                               # doctest: +SKIP
     dd.DataFrame<x, divisions=(None, None)>
     >>> b                                               # doctest: +SKIP

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -381,6 +381,13 @@ def ensure_not_exists(filename):
             raise
 
 
+def _skip_doctest(line):
+    if '>>>' in line:
+        return line + '    # doctest: +SKIP'
+    else:
+        return line
+
+
 def derived_from(original_klass, version=None, ua_args=[]):
     """Decorator to attach original class's docstring to the wrapped method.
 
@@ -417,6 +424,7 @@ def derived_from(original_klass, version=None, ua_args=[]):
                         "        Dask doesn't supports following argument(s).\n\n")
                 args = ''.join(['        * {0}\n'.format(a) for a in not_supported])
                 doc = doc + note + args
+            doc = '\n'.join([_skip_doctest(line) for line in doc.split('\n')])
             method.__doc__ = doc
             return method
 


### PR DESCRIPTION
Follow-up for docstring issue discussed in #683 comments. 

- Define a decorator which automatically attach corresponding base class docstring.
- Calling unsupported function should raise more understandable errors. For example, calling  ``dd.DataFrame().nlargest`` with pandas 0.16.2 or earlier raises:

```
ddf.nlargest()
# NotImplementedError: Base package doesn't support 'nlargest'. Use pandas 0.17.0 or later to use this method.
```

- Clarify keywords not-supported by Dask as below (add "Notes" by checking function definition). [Full output is on my gist](https://gist.githack.com/sinhrks/8a6ab517723160d2abaa/raw/be97f0ecab6364d92996b9939bd3d4745c363f49/dataframe-api.html)

![2015-09-19 22 50 47](https://cloud.githubusercontent.com/assets/1696302/9976490/f9a81618-5f20-11e5-94bf-2257cd95c851.png)
 
- Replace ``getargspec`` to ``getfullargspec`` in python3, as ``getargspec`` is deprecated in 3.5. Even though these are not the same, but it looks replaceable in dask's usage.

This PR is under work, because of doctest failure in attached docstrings. I'm searching an easy way to skip them. Ugly solution is append ``... SKIP`` to every lines... :( 