### PR TITLE
Scheduler docs

### DIFF
--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -29,7 +29,7 @@ def get(dsk, result, cache=None, num_workers=None, **kwargs):
         A dask dictionary specifying a workflow
     result: key or list of keys
         Keys corresponding to desired data
-    nthreads: integer of thread count
+    num_workers: integer of thread count
         The number of threads to use in the ThreadPool that will actually execute tasks
     cache: dict-like (optional)
         Temporary storage of results

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -1,0 +1,3 @@
+@import url("theme.css");
+
+a.internal em {font-style: normal}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,2 @@
+{% extends "!layout.html" %}
+{% set css_files = css_files + ["_static/style.css"] %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,9 +92,14 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = 'default'
+# Taken from docs.readthedocs.org:
+# on_rtd is whether we are on readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,12 +40,20 @@ Dask collections are the main interaction point for users.  They look like
 NumPy and pandas but generate dask graphs internally.  If you are a dask *user*
 then you should start here.
 
+* :doc:`array`
+* :doc:`bag`
+* :doc:`dataframe`
+* :doc:`imperative`
+
 .. toctree::
    :maxdepth: 1
+   :hidden:
+   :caption: Collections
 
    array.rst
    bag.rst
    dataframe.rst
+   imperative.rst
 
 **Graphs:**
 
@@ -53,13 +61,19 @@ Dask graphs encode algorithms in a simple format involving Python dicts,
 tuples, and functions.  This graph format can be used in isolation from the
 dask collections.  If you are a *developer* then you should start here.
 
+* :doc:`graphs`
+* :doc:`spec`
+* :doc:`custom-graphs`
+* :doc:`optimize`
+
 .. toctree::
    :maxdepth: 1
+   :hidden:
+   :caption: Graphs
 
    graphs.rst
    spec.rst
    custom-graphs.rst
-   imperative.rst
    optimize.rst
 
 **Scheduling:**
@@ -68,20 +82,45 @@ Schedulers execute task graphs.  After a collection produces a graph we execute
 this graph in parallel, either using all of the cores on a single workstation
 or using a distributed cluster.
 
+* :doc:`shared`
+* :doc:`distributed`
+
 .. toctree::
    :maxdepth: 1
+   :hidden:
+   :caption: Schedulers
 
    shared.rst
    distributed.rst
 
-**Other**
+**Inspecting and Diagnosing Graphs**
+
+Parallel code can be tricky to debug and profile. Dask provides a few tools to
+help make debugging and profiling graph execution easier.
+
+* :doc:`inspect`
+* :doc:`diagnostics`
 
 .. toctree::
    :maxdepth: 1
+   :hidden:
+   :caption: Diagnostics
 
-   install.rst
    inspect.rst
    diagnostics.rst
+
+**Other**
+
+* :doc:`install`
+* :doc:`faq`
+* :doc:`spark`
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: More information
+
+   install.rst
    faq.rst
    spark.rst
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,6 +82,7 @@ Schedulers execute task graphs.  After a collection produces a graph we execute
 this graph in parallel, either using all of the cores on a single workstation
 or using a distributed cluster.
 
+* :doc:`scheduler-overview`
 * :doc:`shared`
 * :doc:`distributed`
 
@@ -90,6 +91,7 @@ or using a distributed cluster.
    :hidden:
    :caption: Schedulers
 
+   scheduler-overview.rst
    shared.rst
    distributed.rst
 

--- a/docs/source/scheduler-overview.rst
+++ b/docs/source/scheduler-overview.rst
@@ -1,7 +1,7 @@
 Scheduler Overview
 ==================
 
-Once a dask graph is created, a scheduler is needed to run it. Dask currently
+After we create a dask graph, we use a scheduler to run it. Dask currently
 implements a few different schedulers:
 
 - ``dask.threaded.get``: a scheduler backed by a thread pool
@@ -70,6 +70,10 @@ are shared.
     >>> da.compute(y, z)    # Compute y and z, sharing intermediate results
     (5050, 50.5)
 
+Here the ``x + 1`` intermediate was only computed once, while calling
+``y.compute()`` and ``z.compute()`` would compute it twice. For large graphs
+that share many intermediates this can be a big performance gain.
+
 The ``compute`` function works with any dask collection, and is found in
 ``dask.base``. For convenience it has also been imported into the top level
 namespace of each collection.
@@ -97,7 +101,7 @@ may want to use a different scheduler. There are two ways to do this:
 1. Using the ``get`` keyword in the ``compute`` method
 
     .. code-block:: python
-        
+
         >>> x.sum().compute(get=dask.multiprocessing.get)
 
 2. Using ``set_options``. This can be used either as a context manager, or to
@@ -136,6 +140,26 @@ global pool set with ``set_options``:
 
 For more information on the individual options for each scheduler, see the
 docstrings for each scheduler ``get`` function.
+
+
+Debugging the schedulers
+------------------------
+
+Debugging parallel code can be difficult, as conventional tools such as ``pdb``
+don't work well with multiple threads or processes. To get around this when
+debugging, it is recommeneded to use the synchronous scheduler found at
+``dask.async.get_sync``. This runs everything serially, allowing it to work
+well with ``pdb``.
+
+.. code-block:: python
+
+    >>> set_options(get=dask.async.get_sync)
+    >>> x.sum().compute()    # This computation runs serially instead of in parallel
+
+
+The shared memory schedulers also provide a set of callbacks that can be used
+for diagnosing and profiling. You can learn more about scheduler callbacks and
+diagnostics :doc:`here <diagnostics>`.
 
 
 More Information


### PR DESCRIPTION
- Add doc page giving overview of scheduler interface, how to use `get` and `compute` functions, and how to configure the schedulers
- Can now build docs locally with readthedocs template, which helps with debugging the format
- Added headers to the sidebar to break pages into sections (example sidebar [here](https://read-the-docs.readthedocs.org/en/latest/))

Closes #682.