### PR TITLE
Fixing issues with UTF-16/32 encodings and dataframe.read_csv

### DIFF
--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -731,12 +731,14 @@ def test_from_pandas_with_datetime_index():
         eq(df, ddf)
 
 
+ar = pd.Series(range(0, 100))
+br = ar % 7
+cr = br * 3.3
+dr = br / 1.9836
+test_df = pd.concat([ar, br, cr, dr], axis=1)
+
+
 def test_encoding_gh601():
-    ar = pd.Series(range(0, 100))
-    br = ar % 7
-    cr = br * 3.3
-    dr = br / 1.9836
-    test_df = pd.concat([ar, br, cr, dr], axis=1)
     with tmpfile('.csv') as fn:
         test_df.to_csv(fn, encoding='utf-16')
 
@@ -744,6 +746,8 @@ def test_encoding_gh601():
         d = dd.read_csv(fn, encoding='utf-16', chunkbytes=1000)
         d.compute()
 
+
+def test_encoding_gh601_utf_16_le():
     with tmpfile('.csv') as fn:
         test_df.to_csv(fn, encoding='utf-16-le')
 
@@ -751,30 +755,11 @@ def test_encoding_gh601():
         d = dd.read_csv(fn, encoding='utf-16-le', chunkbytes=1000)
         d.compute()
 
+
+def test_encoding_gh601_utf_16_be():
     with tmpfile('.csv') as fn:
         test_df.to_csv(fn, encoding='utf-16-be')
 
         a = pd.read_csv(fn, encoding='utf-16-be')
         d = dd.read_csv(fn, encoding='utf-16-be', chunkbytes=1000)
-        d.compute()
-
-    with tmpfile('.csv') as fn:
-        test_df.to_csv(fn, encoding='utf-32')
-
-        a = pd.read_csv(fn, encoding='utf-32')
-        d = dd.read_csv(fn, encoding='utf-32', chunkbytes=1000)
-        d.compute()
-
-    with tmpfile('.csv') as fn:
-        test_df.to_csv(fn, encoding='utf-32-le')
-
-        a = pd.read_csv(fn, encoding='utf-32-le')
-        d = dd.read_csv(fn, encoding='utf-32-le', chunkbytes=1000)
-        d.compute()
-
-    with tmpfile('.csv') as fn:
-        test_df.to_csv(fn, encoding='utf-32-be')
-
-        a = pd.read_csv(fn, encoding='utf-32-be')
-        d = dd.read_csv(fn, encoding='utf-32-be', chunkbytes=1000)
         d.compute()

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -614,15 +614,15 @@ def test_to_bag():
 def test_csv_expands_dtypes():
     with filetext(text) as fn:
         a = dd.read_csv(fn, chunkbytes=30, dtype={})
-        a_kwargs = list(a.dask.values())[0][-1]
+        a_kwargs = list(a.dask.values())[0][-2]
 
         b = dd.read_csv(fn, chunkbytes=30)
-        b_kwargs = list(b.dask.values())[0][-1]
+        b_kwargs = list(b.dask.values())[0][-2]
 
         assert a_kwargs['dtype'] == b_kwargs['dtype']
 
         a = dd.read_csv(fn, chunkbytes=30, dtype={'amount': float})
-        a_kwargs = list(a.dask.values())[0][-1]
+        a_kwargs = list(a.dask.values())[0][-2]
 
         assert a_kwargs['dtype']['amount'] == float
 

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -729,3 +729,52 @@ def test_from_pandas_with_datetime_index():
                          parse_dates=['Date'])
         ddf = dd.from_pandas(df, 2)
         eq(df, ddf)
+
+
+def test_encoding_gh601():
+    ar = pd.Series(range(0, 100))
+    br = ar % 7
+    cr = br * 3.3
+    dr = br / 1.9836
+    test_df = pd.concat([ar, br, cr, dr], axis=1)
+    with tmpfile('.csv') as fn:
+        test_df.to_csv(fn, encoding='utf-16')
+
+        a = pd.read_csv(fn, encoding='utf-16')
+        d = dd.read_csv(fn, encoding='utf-16', chunkbytes=1000)
+        d.compute()
+
+    with tmpfile('.csv') as fn:
+        test_df.to_csv(fn, encoding='utf-16-le')
+
+        a = pd.read_csv(fn, encoding='utf-16-le')
+        d = dd.read_csv(fn, encoding='utf-16-le', chunkbytes=1000)
+        d.compute()
+
+    with tmpfile('.csv') as fn:
+        test_df.to_csv(fn, encoding='utf-16-be')
+
+        a = pd.read_csv(fn, encoding='utf-16-be')
+        d = dd.read_csv(fn, encoding='utf-16-be', chunkbytes=1000)
+        d.compute()
+
+    with tmpfile('.csv') as fn:
+        test_df.to_csv(fn, encoding='utf-32')
+
+        a = pd.read_csv(fn, encoding='utf-32')
+        d = dd.read_csv(fn, encoding='utf-32', chunkbytes=1000)
+        d.compute()
+
+    with tmpfile('.csv') as fn:
+        test_df.to_csv(fn, encoding='utf-32-le')
+
+        a = pd.read_csv(fn, encoding='utf-32-le')
+        d = dd.read_csv(fn, encoding='utf-32-le', chunkbytes=1000)
+        d.compute()
+
+    with tmpfile('.csv') as fn:
+        test_df.to_csv(fn, encoding='utf-32-be')
+
+        a = pd.read_csv(fn, encoding='utf-32-be')
+        d = dd.read_csv(fn, encoding='utf-32-be', chunkbytes=1000)
+        d.compute()

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -746,5 +746,5 @@ def test_encoding_gh601():
             a = pd.read_csv(fn, encoding=encoding)
             d = dd.read_csv(fn, encoding=encoding, chunkbytes=1000)
             d = d.compute()
-            d.index = range(100)
+            d.index = range(len(d.index))
             assert eq(d, a)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -731,35 +731,20 @@ def test_from_pandas_with_datetime_index():
         eq(df, ddf)
 
 
-ar = pd.Series(range(0, 100))
-br = ar % 7
-cr = br * 3.3
-dr = br / 1.9836
-test_df = pd.concat([ar, br, cr, dr], axis=1)
-
-
 def test_encoding_gh601():
-    with tmpfile('.csv') as fn:
-        test_df.to_csv(fn, encoding='utf-16')
+    encodings = ('utf-16', 'utf-16-le', 'utf-16-be')
+    ar = pd.Series(range(0, 100))
+    br = ar % 7
+    cr = br * 3.3
+    dr = br / 1.9836
+    test_df = pd.concat([ar, br, cr, dr], axis=1)
 
-        a = pd.read_csv(fn, encoding='utf-16')
-        d = dd.read_csv(fn, encoding='utf-16', chunkbytes=1000)
-        d.compute()
+    for encoding in encodings:
+        with tmpfile('.csv') as fn:
+            test_df.to_csv(fn, encoding=encoding)
 
-
-def test_encoding_gh601_utf_16_le():
-    with tmpfile('.csv') as fn:
-        test_df.to_csv(fn, encoding='utf-16-le')
-
-        a = pd.read_csv(fn, encoding='utf-16-le')
-        d = dd.read_csv(fn, encoding='utf-16-le', chunkbytes=1000)
-        d.compute()
-
-
-def test_encoding_gh601_utf_16_be():
-    with tmpfile('.csv') as fn:
-        test_df.to_csv(fn, encoding='utf-16-be')
-
-        a = pd.read_csv(fn, encoding='utf-16-be')
-        d = dd.read_csv(fn, encoding='utf-16-be', chunkbytes=1000)
-        d.compute()
+            a = pd.read_csv(fn, encoding=encoding)
+            d = dd.read_csv(fn, encoding=encoding, chunkbytes=1000)
+            d = d.compute()
+            d.index = range(100)
+            assert eq(d, a)

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -92,10 +92,13 @@ def test_gh606():
     encoding = 'utf-16-le'
     euro = u'\u20ac'
     yen = u'\u00a5'
+    linesep = os.linesep
+
     bin_euro = u'\u20ac'.encode(encoding)
     bin_yen = u'\u00a5'.encode(encoding)
+    bin_linesep = linesep.encode(encoding)
 
-    data = (euro * 10) + '\n' + (yen * 10) + '\n' + (euro * 10)
+    data = (euro * 10) + linesep + (yen * 10) + linesep + (euro * 10)
     bin_data = data.encode(encoding)
 
     with tmpfile() as fn:
@@ -103,10 +106,10 @@ def test_gh606():
             f.write(bin_data)
             f.seek(0)
 
-            stop = len(bin_euro) * 10 + len('\n'.encode(encoding))
+            stop = len(bin_euro) * 10 + len(bin_linesep)
             res = textblock(f, 1, stop, encoding=encoding)
-            assert res == ((yen * 10) + '\n').encode(encoding)
+            assert res == ((yen * 10) + linesep).encode(encoding)
 
-            stop = len(bin_euro) * 10 + len('\n'.encode(encoding))
+            stop = len(bin_euro) * 10 + len(bin_linesep)
             res = textblock(f, 0, stop, encoding=encoding)
-            assert res == ((euro * 10) + '\n' + (yen * 10) + '\n').encode(encoding)
+            assert res == ((euro * 10) + linesep + (yen * 10) + linesep).encode(encoding)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -12,6 +12,7 @@ import types
 import gzip
 import tempfile
 import inspect
+import codecs
 
 from .compatibility import unicode, long, getargspec
 
@@ -137,8 +138,36 @@ def filetexts(d, open=open):
 opens = {'gzip': gzip.open}
 
 
+def get_bom(fn):
+    """
+    Get the Byte Order Mark (BOM) if it exists.
+    """
+    boms = {codecs.BOM_UTF16, codecs.BOM_UTF16_BE, codecs.BOM_UTF16_LE}
+    with open(fn, 'rb') as f:
+        f.seek(0)
+        bom = f.read(2)
+        f.seek(0)
+    if bom in boms:
+        return bom
+    else:
+        return b''
+
+
+def get_bin_linesep(encoding, linesep):
+    """
+    Simply doing linesep.encode(encoding) does not always give you
+    *just* the linesep bytes, for some encodings this prefix's the
+    linesep bytes with the BOM. This function ensures we just get the 
+    linesep bytes.
+    """
+    if encoding == 'utf-16':
+        return linesep.encode('utf-16')[2:]  # [2:] strips bom
+    else:
+        return linesep.encode(encoding)
+
+
 def next_linesep(fo, seek, encoding, linesep):
-    bin_linesep = linesep.encode(encoding)
+    bin_linesep = get_bin_linesep(encoding, linesep)
     data = b''
     data_len = 0
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -142,7 +142,7 @@ def get_bom(fn):
     """
     Get the Byte Order Mark (BOM) if it exists.
     """
-    boms = {codecs.BOM_UTF16, codecs.BOM_UTF16_BE, codecs.BOM_UTF16_LE}
+    boms = set((codecs.BOM_UTF16, codecs.BOM_UTF16_BE, codecs.BOM_UTF16_LE))
     with open(fn, 'rb') as f:
         f.seek(0)
         bom = f.read(2)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -155,9 +155,9 @@ def get_bom(fn):
 
 def get_bin_linesep(encoding, linesep):
     """
-    Simply doing linesep.encode(encoding) does not always give you
+    Simply doing `linesep.encode(encoding)` does not always give you
     *just* the linesep bytes, for some encodings this prefix's the
-    linesep bytes with the BOM. This function ensures we just get the 
+    linesep bytes with the BOM. This function ensures we just get the
     linesep bytes.
     """
     if encoding == 'utf-16':
@@ -206,7 +206,8 @@ def textblock(file, start, stop, compression=None, encoding=None,
         myopen = opens.get(compression, open)
         f = myopen(file, 'rb')
         try:
-            result = textblock(f, start, stop)
+            result = textblock(f, start, stop, compression=None,
+                               encoding=encoding, linesep=linesep)
         finally:
             f.close()
         return result


### PR DESCRIPTION
UTF 16 and UTF 32 data usually starts with a 2 byte Byte Order Mark (BOM) that indicates encoding and its endianess.

This is a problem if we break a file into chunks because only the first chunk will have the BOM.

This is what causes problems when `dask.dataframe.read_csv` tries to read a `utf-16` file.
 
The encoding of a file can be specified with the endianess: `utf-16 -> utf-16-be, utf-16-le`. So I tried
to fix this by reading the BOM and changing the encoding passed to `pandas.read_csv` to include the endianess.  See [here](https://github.com/blaze/dask/compare/blaze:master...cowlicks:bom?expand=1#diff-2a4c3ed91854a1a70080d69581e762b3R51).

This doesn't work. I'm not sure why.