### PR TITLE
Hash numpy arrays and pandas dataframes in tokenize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytest numpy pip coverage toolz pandas scikit-learn cytoolz dill pyzmq ipython bcolz chest blosc cython pytables h5py psutil
+  - conda install pytest numpy pip coverage toolz pandas scikit-learn cytoolz dill pyzmq ipython bcolz chest blosc cython pytables h5py psutil mock
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then conda install bokeh; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then conda install ipyparallel; fi

--- a/dask/base.py
+++ b/dask/base.py
@@ -138,21 +138,25 @@ with ignoring(ImportError):
 
     @partial(normalize_token.register, pd.Index)
     def normalize_index(ind):
-        return tokenize(ind.name, ind.values)
+        return [ind.name, normalize_token(ind.values)]
 
     @partial(normalize_token.register, pd.Categorical)
     def normalize_categorical(cat):
-        return tokenize(cat.codes, cat.categories, cat.ordered)
+        return [normalize_token(cat.codes),
+                normalize_token(cat.categories),
+                cat.ordered]
 
     @partial(normalize_token.register, pd.Series)
     def normalize_series(s):
-        return tokenize(s.name, s._data.blocks[0].values, s.dtype, s.index)
+        return [s.name, s.dtype,
+                normalize_token(s._data.blocks[0].values),
+                normalize_token(s.index)]
 
     @partial(normalize_token.register, pd.DataFrame)
     def normalize_dataframe(df):
         data = [block.values for block in df._data.blocks]
         data += [df.columns, df.index]
-        return tokenize(*data)
+        return list(map(normalize_token, data))
 
 
 with ignoring(ImportError):

--- a/dask/base.py
+++ b/dask/base.py
@@ -160,13 +160,16 @@ with ignoring(ImportError):
     @partial(normalize_token.register, np.ndarray)
     def normalize_array(x):
         if x.dtype.hasobject:
-            L = x.flat.tolist()
             try:
-                data = md5('-'.join(L)).hexdigest()
+                data = md5('-'.join(x.flat)).hexdigest()
             except TypeError:
-                data = md5('-'.join(map(str, L))).hexdigest()
+                data = md5('-'.join(map(str, x.flat))).hexdigest()
         else:
-            data = md5(x.data).hexdigest()
+            try:
+                buffer = x.data
+            except AttributeError:
+                buffer = np.array(x).data  # force a copy
+            data = md5(buffer).hexdigest()
         return (data, x.dtype, x.shape, x.strides)
 
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -135,15 +135,31 @@ normalize_token.register(dict, lambda a: tuple(sorted(a.items())))
 
 with ignoring(ImportError):
     import pandas as pd
-    normalize_token.register(pd.DataFrame,
-            lambda a: (id(a), len(a), list(a.columns)))
-    normalize_token.register(pd.Series, lambda a: (id(a), len(a), a.name))
+
+    @partial(normalize_token.register, pd.Index)
+    def normalize_index(ind):
+        return tokenize(ind.name, ind.values)
+
+    @partial(normalize_token.register, pd.Categorical)
+    def normalize_categorical(cat):
+        return tokenize(cat.codes, cat.categories, cat.ordered)
+
+    @partial(normalize_token.register, pd.Series)
+    def normalize_series(s):
+        return tokenize(s.name, s._data.blocks[0].values, s.dtype, s.index)
+
+    @partial(normalize_token.register, pd.DataFrame)
+    def normalize_dataframe(df):
+        data = [block.values for block in df._data.blocks]
+        data += [df.columns, df.index]
+        return tokenize(*data)
+
 
 with ignoring(ImportError):
     import numpy as np
     @partial(normalize_token.register, np.ndarray)
     def normalize_array(x):
-        if x.dtype.hasobject == 'O':
+        if x.dtype.hasobject:
             L = x.flat.tolist()
             try:
                 data = md5('-'.join(L)).hexdigest()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -54,6 +54,11 @@ def test_tokenize_numpy_array_supports_uneven_sizes():
     tokenize(np.random.random(7).astype(dtype='i2'))
 
 
+def test_tokenize_discontiguous_numpy_array():
+    np = pytest.importorskip('numpy')
+    tokenize(np.random.random(8)[::2])
+
+
 def test_tokenize_numpy_array_on_object_dtype():
     np = pytest.importorskip('numpy')
     assert tokenize(np.array(['a', 'aa', 'aaa'], dtype=object)) == \

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -43,6 +43,27 @@ def test_tokenize():
     assert tokenize(a, b) == tokenize(normalize_token(a), normalize_token(b))
 
 
+def test_tokenize_numpy_array_consistent_on_values():
+    np = pytest.importorskip('numpy')
+    assert tokenize(np.random.RandomState(1234).random_sample(1000)) == \
+           tokenize(np.random.RandomState(1234).random_sample(1000))
+
+
+def test_tokenize_numpy_array_supports_uneven_sizes():
+    np = pytest.importorskip('numpy')
+    tokenize(np.random.random(7).astype(dtype='i2'))
+
+
+def test_tokenize_numpy_array_on_object_dtype():
+    np = pytest.importorskip('numpy')
+    assert tokenize(np.array(['a', 'aa', 'aaa'], dtype=object)) == \
+           tokenize(np.array(['a', 'aa', 'aaa'], dtype=object))
+    assert tokenize(np.array(['a', None, 'aaa'], dtype=object)) == \
+           tokenize(np.array(['a', None, 'aaa'], dtype=object))
+    assert tokenize(np.array([(1, 'a'), (1, None), (1, 'aaa')], dtype=object)) == \
+           tokenize(np.array([(1, 'a'), (1, None), (1, 'aaa')], dtype=object))
+
+
 da = pytest.importorskip('dask.array')
 import numpy as np
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -64,6 +64,22 @@ def test_tokenize_numpy_array_on_object_dtype():
            tokenize(np.array([(1, 'a'), (1, None), (1, 'aaa')], dtype=object))
 
 
+def test_tokenize_pandas():
+    a = pd.DataFrame({'x': [1, 2, 3], 'y': ['4', 'asd', None]}, index=[1, 2, 3])
+    b = pd.DataFrame({'x': [1, 2, 3], 'y': ['4', 'asd', None]}, index=[1, 2, 3])
+
+    assert tokenize(a) == tokenize(b)
+    b.index.name = 'foo'
+    assert tokenize(a) != tokenize(b)
+
+    a = pd.DataFrame({'x': [1, 2, 3], 'y': ['a', 'b', 'a']})
+    b = pd.DataFrame({'x': [1, 2, 3], 'y': ['a', 'b', 'a']})
+    a['z'] = a.y.astype('category')
+    assert tokenize(a) != tokenize(b)
+    b['z'] = a.y.astype('category')
+    assert tokenize(a) == tokenize(b)
+
+
 da = pytest.importorskip('dask.array')
 import numpy as np
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -59,6 +59,16 @@ def test_tokenize_discontiguous_numpy_array():
     tokenize(np.random.random(8)[::2])
 
 
+def test_tokenize_numpy_datetime():
+    np = pytest.importorskip('numpy')
+    tokenize(np.array(['2000-01-01T12:00:00'], dtype='M8[ns]'))
+
+
+def test_tokenize_numpy_scalar():
+    np = pytest.importorskip('numpy')
+    tokenize(np.array(1.0, dtype='f8'))
+
+
 def test_tokenize_numpy_array_on_object_dtype():
     np = pytest.importorskip('numpy')
     assert tokenize(np.array(['a', 'aa', 'aaa'], dtype=object)) == \


### PR DESCRIPTION
This provides value-based hashing for numpy arrays and pandas dataframes.  This should help with consistent hashing when creating tokens in dask graphs.  This converts the objects into buffers and then uses `md5`.

cc @jcrist 

```python
In [1]: import pandas as pd

In [2]: import numpy as np

In [3]: A = pd.DataFrame({'x': np.arange(1000000), 'y': list('abcdefghij'*100000)})
In [4]: B = pd.DataFrame({'x': np.arange(1000000), 'y': list('abcdefghij'*100000)})

In [5]: from dask.base import tokenize

In [6]: %time tokenize(A)
CPU times: user 45.8 ms, sys: 593 µs, total: 46.4 ms
Wall time: 45.7 ms
Out[6]: '53bd8832e0cc1c8a2da346ba0b7d4685'

In [7]: %time tokenize(B)
CPU times: user 40.3 ms, sys: 298 µs, total: 40.6 ms
Wall time: 39.9 ms
Out[7]: '53bd8832e0cc1c8a2da346ba0b7d4685'
```