### PR TITLE
(WIP) Fix dataframe.io API docs

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -8,9 +8,12 @@ Create DataFrames
 
 .. autosummary::
    read_csv
+   read_hdf
    from_array
    from_pandas
    from_bcolz
+   from_castra
+   from_dask_array
 
 .. currentmodule:: dask.dataframe.core
 
@@ -57,6 +60,9 @@ Other functions
 .. currentmodule:: dask.dataframe.io
 
 .. autofunction:: read_csv
+.. autofunction:: read_hdf
 .. autofunction:: from_array
 .. autofunction:: from_pandas
 .. autofunction:: from_bcolz
+.. autofunction:: from_castra
+.. autofunction:: from_dask_array


### PR DESCRIPTION
Added some functions to the list. 

One problem is all kwds in ``pd.read_csv`` are listed as "not supported" because ``dd.read_csv`` uses ``kwargs`` to handle them at once. I think there are some unsupported kwds like ``skiprows`` and ``skipfooter`` at a glance. 

Considering a easy way to apply it to the doc.