### PR TITLE
Add reshape and flatten for dask.array

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
-        from_array, choose, where, coarsen, insert, broadcast_to, fromfunction,
-        unique, store, squeeze, topk, bincount, histogram, map_blocks, atop,
-        to_hdf5, dot, cov, array, to_npy_stack, from_npy_stack)
+        from_array, choose, where, coarsen, insert, broadcast_to, ravel,
+        fromfunction, unique, store, squeeze, topk, bincount, histogram,
+        map_blocks, atop, to_hdf5, dot, cov, array, to_npy_stack,
+        from_npy_stack)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,
         hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, choose, where, coarsen, insert, broadcast_to, ravel,
-        fromfunction, unique, store, squeeze, topk, bincount, histogram,
-        map_blocks, atop, to_hdf5, dot, cov, array, to_npy_stack,
+        reshape, fromfunction, unique, store, squeeze, topk, bincount,
+        histogram, map_blocks, atop, to_hdf5, dot, cov, array, to_npy_stack,
         from_npy_stack)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2154,6 +2154,13 @@ def unravel(array, shape):
 @wraps(np.reshape)
 def reshape(array, shape):
     shape = tuple(shape)
+    known_sizes = [s for s in shape if s != -1]
+    if len(known_sizes) < len(shape):
+        if len(known_sizes) - len(shape) > 1:
+            raise ValueError('can only specify one unknown dimension')
+        missing_size = int(array.size / np.prod(known_sizes))
+        shape = tuple(missing_size if s == -1 else s for s in shape)
+
     if np.prod(shape) != array.size:
         raise ValueError('total size of new array must be unchanged')
     return unravel(ravel(array), shape)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -883,6 +883,10 @@ class Array(Base):
 
     flatten = ravel
 
+    @wraps(np.reshape)
+    def reshape(self, shape):
+        return reshape(self, shape)
+
     @wraps(topk)
     def topk(self, k):
         return topk(k, self)
@@ -2143,6 +2147,14 @@ def unravel(array, shape):
             return stack([unravel(array[n * trailing_size
                                         : (n + 1) * trailing_size], shape[1:])
                           for n in range(shape[0])])
+
+
+@wraps(np.reshape)
+def reshape(array, shape):
+    shape = tuple(shape)
+    if np.prod(shape) != array.size:
+        raise ValueError('total size of new array must be unchanged')
+    return unravel(ravel(array), shape)
 
 
 def offset_func(func, offset, *args):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -884,7 +884,9 @@ class Array(Base):
     flatten = ravel
 
     @wraps(np.reshape)
-    def reshape(self, shape):
+    def reshape(self, *shape):
+        if len(shape) == 1 and not isinstance(shape[0], Number):
+            shape = shape[0]
         return reshape(self, shape)
 
     @wraps(topk)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -660,6 +660,16 @@ def test_reshape():
     assert len(reshaped.dask) == len(a.dask) + 2
 
 
+def test_reshape_unknown_dimensions():
+    for original_shape in [(24,), (2, 12), (2, 3, 4)]:
+        for new_shape in [(-1,), (2, -1), (-1, 3, 4)]:
+            x = np.random.randint(10, size=original_shape)
+            a = from_array(x, 4)
+            assert eq(x.reshape(new_shape), a.reshape(new_shape))
+
+    assert raises(ValueError, lambda: reshape(a, (-1, -1)))
+
+
 def test_full():
     d = da.full((3, 4), 2, chunks=((2, 1), (2, 2)))
     assert d.chunks == ((2, 1), (2, 2))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -649,6 +649,7 @@ def test_reshape():
                 assert eq(x.reshape(new_shape), a.reshape(new_shape))
 
     assert raises(ValueError, lambda: reshape(a, (100,)))
+    assert eq(x.reshape(*new_shape), a.reshape(*new_shape))
     assert eq(np.reshape(x, new_shape), reshape(a, new_shape))
 
     # verify we can reshape a single chunk array without too many tasks

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -639,6 +639,26 @@ def test_unravel():
     assert unravel(a, a.shape) is a
 
 
+def test_reshape():
+    shapes = [(24,), (2, 12), (2, 3, 4)]
+    for original_shape in shapes:
+        for new_shape in shapes:
+            for chunks in [2, 4, 12]:
+                x = np.random.randint(10, size=original_shape)
+                a = from_array(x, chunks)
+                assert eq(x.reshape(new_shape), a.reshape(new_shape))
+
+    assert raises(ValueError, lambda: reshape(a, (100,)))
+    assert eq(np.reshape(x, new_shape), reshape(a, new_shape))
+
+    # verify we can reshape a single chunk array without too many tasks
+    x = np.random.randint(10, size=(10, 20))
+    a = from_array(x, 20)  # all one chunk
+    reshaped = a.reshape((20, 10))
+    assert eq(x.reshape((20, 10)), reshaped)
+    assert len(reshaped.dask) == len(a.dask) + 2
+
+
 def test_full():
     d = da.full((3, 4), 2, chunks=((2, 1), (2, 2)))
     assert d.chunks == ((2, 1), (2, 2))


### PR DESCRIPTION
Fixes #570

Currently only does `order='C'`. A future PR might add the option for `order='K'`, which could be useful in some cases.

Example usage:
```
In [1]: import numpy as np

In [2]: import dask.array as da

In [3]: a = da.from_array(np.random.randint(10, size=(3, 4)), chunks=2)

In [4]: a.reshape(2, 6).compute()
Out[4]:
array([[7, 9, 6, 4, 2, 7],
       [7, 8, 3, 5, 4, 7]])

In [5]: a.reshape(-1).compute()
Out[5]: array([7, 9, 6, 4, 2, 7, 7, 8, 3, 5, 4, 7])

In [7]: a.ravel().compute()
Out[7]: array([7, 9, 6, 4, 2, 7, 7, 8, 3, 5, 4, 7])
```