### PR TITLE
Support struct dtypes in dd.from_dask_array

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -517,9 +517,16 @@ def from_dask_array(x, columns=None):
     divisions[-1] -= 1
 
     if x.ndim == 1:
-        dsk = dict(((name, i), (pd.Series, chunk, ind, x.dtype, columns))
-                for i, (chunk, ind) in enumerate(zip(x._keys(), index)))
-        return Series(merge(x.dask, dsk), name, columns, divisions)
+        if x.dtype.names is None:
+            dsk = dict(((name, i), (pd.Series, chunk, ind, x.dtype, columns))
+                    for i, (chunk, ind) in enumerate(zip(x._keys(), index)))
+            return Series(merge(x.dask, dsk), name, columns, divisions)
+        else:
+            if columns is None:
+                columns = x.dtype.names
+            dsk = dict(((name, i), (pd.DataFrame, chunk, ind, columns))
+                    for i, (chunk, ind) in enumerate(zip(x._keys(), index)))
+            return DataFrame(merge(x.dask, dsk), name, columns, divisions)
 
     elif x.ndim == 2:
         if columns is None:

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -385,6 +385,17 @@ def test_from_dask_array_raises():
         assert '3' in str(e)
 
 
+def test_from_dask_array_struct_dtype():
+    x = np.array([(1, 'a'), (2, 'b')], dtype=[('a', 'i4'), ('b', 'object')])
+    y = da.from_array(x, chunks=(1,))
+    df = dd.from_dask_array(y)
+    assert tuple(df.columns) == y.dtype.names
+    eq(df, pd.DataFrame(x))
+
+    eq(dd.from_dask_array(y, columns=['b', 'a']),
+       pd.DataFrame(x, columns=['b', 'a']))
+
+
 def test_to_castra():
     pytest.importorskip('castra')
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],


### PR DESCRIPTION
Example
-------

```python
In [1]: import numpy as np

In [2]: x = np.array([(1, 'a'), (2, 'b')], dtype=[('a', 'i4'), ('b',
'object')])

In [3]: import dask.array as da

In [4]: y = da.from_array(x, chunks=(1,))

In [5]: import dask.dataframe as dd

In [6]: df = dd.from_dask_array(y)

In [7]: df
Out[7]: dd.DataFrame<from-dask-arrayd332533ff03b86defb56f10bc4fd3468,
divisions=(0, 1, 1)>

In [8]: df.compute()
Out[8]:
   a  b
0  1  a
1  2  b
```
Fixes https://github.com/blaze/dask/issues/747