### PR TITLE
Replace dask.get from core.get to async.get_sync

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from .core import istask, get
+from .core import istask
 from .context import set_options
-
+from .async import get_sync as get
 try:
     from .imperative import do, value
 except ImportError:


### PR DESCRIPTION
We really shouldn't publish core.get anywhere, particularly in the
top level API.