### PR TITLE
A few imperative fixes

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -6,6 +6,7 @@ from functools import partial
 from graphviz import Digraph
 
 from .core import istask, get_dependencies, ishashable
+from .utils import funcname
 
 
 def task_label(task):
@@ -41,13 +42,6 @@ def has_sub_tasks(task):
         return any(has_sub_tasks(i) for i in task)
     else:
         return False
-
-
-def funcname(func):
-    """Get the name of a function."""
-    while hasattr(func, 'func'):
-        func = func.func
-    return func.__name__
 
 
 def name(x):

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -6,7 +6,7 @@ from collections import Iterator
 from toolz import merge, unique, curry
 
 from .optimize import cull, fuse
-from .utils import concrete
+from .utils import concrete, funcname
 from . import base
 from .compatibility import apply
 from . import threaded
@@ -65,7 +65,7 @@ def to_task_dasks(expr):
     if isinstance(expr, Value):
         return expr.key, expr._dasks
     if isinstance(expr, base.Base):
-        name = tokenize(expr, True)
+        name = tokenize(expr, pure=True)
         keys = expr._keys()
         dsk = expr._optimize(expr.dask, keys)
         dsk[name] = (expr._finalize, expr, (concrete, keys))
@@ -120,7 +120,7 @@ def applyfunc(func, args, kwargs, pure=False):
         task = (apply, func, (list, list(args)), dask_kwargs)
     else:
         task = (func,) + args
-    name = tokenize(*task, pure=pure)
+    name = funcname(func) + '-' + tokenize(*task, pure=pure)
     dasks = flat_unique(dasks)
     dasks.append({name: task})
     return Value(name, dasks)
@@ -248,7 +248,7 @@ class Value(base.Base):
 
     def __getattr__(self, attr):
         if not attr.startswith('_'):
-            return do(getattr, True)(self, attr)
+            return do(getattr, pure=True)(self, attr)
         else:
             raise AttributeError("Attribute {0} not found".format(attr))
 
@@ -347,10 +347,9 @@ def value(val, name=None):
     >>> res.compute()  # doctest: +SKIP
     AttributeError("'list' object has no attribute 'not_a_real_method'")
     """
-
     if isinstance(val, Value):
         return val
-    name = name or tokenize(val, True)
+    name = name or (type(val).__name__ + '-' + tokenize(val, pure=True))
     task, dasks = to_task_dasks(val)
     dasks.append({name: task})
     return Value(name, dasks)

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -262,7 +262,7 @@ class Value(base.Base):
         raise TypeError("Value objects are not iterable")
 
     def __call__(self, *args, **kwargs):
-        return do(apply)(self, args, kwargs)
+        return do(apply, kwargs.pop('pure', False))(self, args, kwargs)
 
     def __bool__(self):
         raise TypeError("Truth of Value objects is not supported")
@@ -346,10 +346,17 @@ def value(val, name=None):
     >>> res = a.not_a_real_method()
     >>> res.compute()  # doctest: +SKIP
     AttributeError("'list' object has no attribute 'not_a_real_method'")
+
+    Methods are assumed to be impure by default, meaning that subsequent calls
+    may return different results. To assume purity, set `pure=True`. This
+    allows sharing of any intermediate values.
+
+    >>> a.count(2, pure=True).key == a.count(2, pure=True).key
+    True
     """
     if isinstance(val, Value):
         return val
-    name = name or (type(val).__name__ + '-' + tokenize(val, pure=True))
     task, dasks = to_task_dasks(val)
+    name = name or (type(val).__name__ + '-' + tokenize(task, pure=True))
     dasks.append({name: task})
     return Value(name, dasks)

--- a/dask/tests/test_imperative.py
+++ b/dask/tests/test_imperative.py
@@ -54,6 +54,7 @@ def test_methods():
     a = value("a b c d e")
     assert a.split(' ').compute() == ['a', 'b', 'c', 'd', 'e']
     assert a.upper().replace('B', 'A').split().count('A').compute() == 2
+    assert a.split(' ', pure=True).key == a.split(' ', pure=True).key
 
 
 def test_attributes():

--- a/dask/tests/test_imperative.py
+++ b/dask/tests/test_imperative.py
@@ -209,3 +209,13 @@ def test_array_bag_imperative():
     seq = [arr1, arr2, darr1, darr2, b]
     out = do(sum)([i.sum() for i in seq])
     assert out.compute() == 2*arr1.sum() + 2*arr2.sum() + sum([1, 2, 3])
+
+
+def test_key_names_include_function_names():
+    def myfunc(x):
+        return x + 1
+    assert do(myfunc)(1).key.startswith('myfunc')
+
+
+def test_key_names_include_type_names():
+    assert value(1).key.startswith('int')

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -498,3 +498,13 @@ def derived_from(original_klass, version=None, ua_args=[]):
                 raise NotImplementedError(msg)
             return wrapped
     return wrapper
+
+
+def funcname(func):
+    """Get the name of a function."""
+    while hasattr(func, 'func'):
+        func = func.func
+    try:
+        return func.__name__
+    except:
+        return str(func)


### PR DESCRIPTION
- Keys in imperative are prefixed with function name or value type
- Fix calls to `tokenize` to specify pure keyword
- Allow methods on `Value` objects to be pure with a `pure` keyword.

Supersedes #779.