### PR TITLE
[WIP] Cache profiling

### DIFF
--- a/dask/diagnostics/__init__.py
+++ b/dask/diagnostics/__init__.py
@@ -1,4 +1,4 @@
-from .profile import Profiler, ResourceProfiler
+from .profile import Profiler, ResourceProfiler, CacheProfiler
 from .progress import ProgressBar
 try:
     from .profile_visualize import visualize

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -242,11 +242,11 @@ class CacheProfiler(Callback):
 
     The default is to count each task (``metric`` is 1 for all tasks). Other
     functions may used as a metric instead through the ``metric`` keyword. For
-    example, the ``nbytes`` function found in ``chest`` can be used to measure
+    example, the ``nbytes`` function found in ``cachey`` can be used to measure
     the number of bytes in the cache.
 
-    >>> from chest.core import nbytes    # doctest: +SKIP
-    >>> with CacheProfiler(metric=nbytes):  # doctest: +SKIP
+    >>> from cachey import nbytes    # doctest: +SKIP
+    >>> with CacheProfiler(metric=nbytes) as prof:  # doctest: +SKIP
     ...     get(dsk, 'z')
 
     The profiling results can be visualized in a bokeh plot using the

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -210,3 +210,110 @@ class _Tracker(Process):
             elif msg == 'start':
                 self._collect()
         self.child_conn.close()
+
+
+CacheData = namedtuple('CacheData', ('key', 'task', 'metric', 'cache_time',
+                                     'free_time'))
+
+
+class CacheProfiler(Callback):
+    """A profiler for dask execution at the scheduler cache level.
+
+    Records the following information for each task:
+        1. Key
+        2. Task
+        3. Size metric
+        4. Cache entry time in seconds since the epoch
+        5. Cache exit time in seconds since the epoch
+
+    Examples
+    --------
+
+    >>> from operator import add, mul
+    >>> from dask.threaded import get
+    >>> dsk = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
+    >>> with CacheProfiler() as prof:
+    ...     get(dsk, 'z')
+    22
+
+    >>> prof.results    # doctest: +SKIP
+    [CacheData('y', (add, 'x', 10), 1, 1435352238.48039, 1435352238.480655),
+     CacheData('z', (mul, 'y', 2), 1, 1435352238.480657, 1435352238.480803)]
+
+    The default is to count each task (``metric`` is 1 for all tasks). Other
+    functions may used as a metric instead through the ``metric`` keyword. For
+    example, the ``nbytes`` function found in ``chest`` can be used to measure
+    the number of bytes in the cache.
+
+    >>> from chest.core import nbytes    # doctest: +SKIP
+    >>> with CacheProfiler(metric=nbytes):  # doctest: +SKIP
+    ...     get(dsk, 'z')
+
+    The profiling results can be visualized in a bokeh plot using the
+    ``visualize`` method. Note that this requires bokeh to be installed.
+
+    >>> prof.visualize() # doctest: +SKIP
+
+    You can activate the profiler globally
+
+    >>> prof.register()  # doctest: +SKIP
+
+    If you use the profiler globally you will need to clear out old results
+    manually.
+
+    >>> prof.clear()
+
+    """
+
+    def __init__(self, metric=None, metric_name=None):
+        self._metric = metric if metric else lambda value: 1
+        if metric_name:
+            self._metric_name = metric_name
+        elif metric:
+            self._metric_name = metric.__name__
+        else:
+            self._metric_name = 'count'
+
+    def __enter__(self):
+        self.clear()
+        return super(CacheProfiler, self).__enter__()
+
+    def _start(self, dsk):
+        self._dsk.update(dsk)
+        if not self._start_time:
+            self._start_time = default_timer()
+
+    def _posttask(self, key, value, dsk, state, id):
+        t = default_timer()
+        self._cache[key] = (self._metric(value), t)
+        for k in state['released'].intersection(self._cache):
+            metric, start = self._cache.pop(k)
+            self.results.append(CacheData(k, dsk[k], metric, start, t))
+
+    def _finish(self, dsk, state, failed):
+        t = default_timer()
+        for k, (metric, start) in self._cache.items():
+            self.results.append(CacheData(k, dsk[k], metric, start, t))
+        self._cache.clear()
+
+    def _plot(self, **kwargs):
+        from .profile_visualize import plot_cache
+        return plot_cache(self.results, self._dsk, self._start_time,
+                          self._metric_name, **kwargs)
+
+    def visualize(self, **kwargs):
+        """Visualize the profiling run in a bokeh plot.
+
+        See also
+        --------
+        dask.diagnostics.profile_visualize.visualize
+        """
+        from .profile_visualize import visualize
+        return visualize(self, **kwargs)
+
+    def clear(self):
+        """Clear out old results from profiler"""
+        self.results = []
+        self._cache = {}
+        self._dsk = {}
+        self._start_time = None

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -341,7 +341,7 @@ def plot_cache(results, dsk, start_time, metric_name, palette='GnBu',
     """
 
     defaults = dict(title="Profile Results",
-                    tools="hover,save,reset,resize,xwheel_zoom,xpan",
+                    tools="hover,save,reset,resize,wheel_zoom,xpan",
                     plot_width=800, plot_height=300)
     defaults.update((k, v) for (k, v) in kwargs.items() if k in
                     bp.Figure.properties())

--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -1,9 +1,9 @@
 from __future__ import division, absolute_import
 
 from itertools import cycle
-from operator import itemgetter
+from operator import itemgetter, add
 
-from toolz import unique, groupby
+from toolz import unique, groupby, accumulate, pluck
 import bokeh.plotting as bp
 from bokeh.io import _state
 from bokeh.palettes import brewer
@@ -310,4 +310,75 @@ def plot_resources(results, palette='GnBu', **kwargs):
     p.add_layout(LinearAxis(y_range_name='memory', axis_label='Memory (MB)'),
                  'right')
     p.xaxis.axis_label = "Time (s)"
+    return p
+
+
+def plot_cache(results, dsk, start_time, metric_name, palette='GnBu',
+               label_size=60, **kwargs):
+    """Visualize the results of profiling in a bokeh plot.
+
+    Parameters
+    ----------
+    results : sequence
+        Output of CacheProfiler.results
+    dsk : dict
+        The dask graph being profiled.
+    start_time : float
+        Start time of the profile.
+    metric_name : string
+        Metric used to measure cache size
+    palette : string, optional
+        Name of the bokeh palette to use, must be key in bokeh.palettes.brewer.
+    label_size: int (optional)
+        Maximum size of output labels in plot, defaults to 60
+    **kwargs
+        Other keyword arguments, passed to bokeh.figure. These will override
+        all defaults set by visualize.
+
+    Returns
+    -------
+    The completed bokeh plot object.
+    """
+
+    defaults = dict(title="Profile Results",
+                    tools="hover,save,reset,resize,xwheel_zoom,xpan",
+                    plot_width=800, plot_height=300)
+    defaults.update((k, v) for (k, v) in kwargs.items() if k in
+                    bp.Figure.properties())
+
+    if results:
+        starts, ends = list(zip(*results))[3:]
+        tics = list(sorted(unique(starts + ends)))
+        groups = groupby(lambda d: pprint_task(d[1], dsk, label_size), results)
+        data = {}
+        for k, vals in groups.items():
+            cnts = dict.fromkeys(tics, 0)
+            for v in vals:
+                cnts[v.cache_time] += v.metric
+                cnts[v.free_time] -= v.metric
+            data[k] = list(accumulate(add, pluck(1, sorted(cnts.items()))))
+
+        tics = [i - start_time for i in tics]
+        p = bp.figure(x_range=[0, max(tics)], **defaults)
+
+        for (key, val), color in zip(data.items(), get_colors(palette, data.keys())):
+            p.line('x', 'y', line_color=color, line_width=3,
+                   source=bp.ColumnDataSource({'x': tics, 'y': val,
+                                               'label': [key for i in val]}))
+
+    else:
+        p = bp.figure(y_range=[0, 10], x_range=[0, 10], **defaults)
+    p.grid.grid_line_color = None
+    p.axis.axis_line_color = None
+    p.axis.major_tick_line_color = None
+    p.yaxis.axis_label = "Cache Size ({0})".format(metric_name)
+    p.xaxis.axis_label = "Time (s)"
+
+    hover = p.select(HoverTool)
+    hover.tooltips = """
+    <div>
+        <span style="font-size: 14px; font-weight: bold;">Task:</span>&nbsp;
+        <span style="font-size: 10px; font-family: Monaco, monospace;">@label</span>
+    </div>
+    """
     return p


### PR DESCRIPTION
Tracks the contents of the cache, and plots it against time. Default metric is just to count by task type, but other metrics can be used (for example `chest.core.nbytes`).

![screen shot 2015-10-14 at 1 57 42 pm](https://cloud.githubusercontent.com/assets/2783717/10494459/17474676-727c-11e5-9b62-90bd2577ba91.png)

TODO:
- [ ] Needs tests
- [ ] Still not happy with the plotting design