### PR TITLE
hdf globbing test uses sync scheduler

### DIFF
--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -662,28 +662,29 @@ def test_hdf_globbing():
         df.to_hdf(os.path.join(tdir, 'two.h5'), '/bar/data', format='table')
         df.to_hdf(os.path.join(tdir, 'two.h5'), '/foo/data', format='table')
 
-        res = dd.read_hdf(os.path.join(tdir, 'one.h5'), '/*/data',
-                          chunksize=2)
-        assert res.npartitions == 2
-        tm.assert_frame_equal(res.compute(), df)
+        with dask.set_options(get=dask.get):
+            res = dd.read_hdf(os.path.join(tdir, 'one.h5'), '/*/data',
+                              chunksize=2)
+            assert res.npartitions == 2
+            tm.assert_frame_equal(res.compute(), df)
 
-        res = dd.read_hdf(os.path.join(tdir, 'one.h5'), '/*/data',
-                          chunksize=2, start=1, stop=3)
-        expected = pd.read_hdf(os.path.join(tdir, 'one.h5'), '/foo/data',
-                               start=1, stop=3)
-        tm.assert_frame_equal(res.compute(), expected)
+            res = dd.read_hdf(os.path.join(tdir, 'one.h5'), '/*/data',
+                              chunksize=2, start=1, stop=3)
+            expected = pd.read_hdf(os.path.join(tdir, 'one.h5'), '/foo/data',
+                                   start=1, stop=3)
+            tm.assert_frame_equal(res.compute(), expected)
 
-        res = dd.read_hdf(os.path.join(tdir, 'two.h5'), '/*/data', chunksize=2)
-        assert res.npartitions == 2 + 2
-        tm.assert_frame_equal(res.compute(), pd.concat([df] * 2))
+            res = dd.read_hdf(os.path.join(tdir, 'two.h5'), '/*/data', chunksize=2)
+            assert res.npartitions == 2 + 2
+            tm.assert_frame_equal(res.compute(), pd.concat([df] * 2))
 
-        res = dd.read_hdf(os.path.join(tdir, '*.h5'), '/foo/data', chunksize=2)
-        assert res.npartitions == 2 + 2
-        tm.assert_frame_equal(res.compute(), pd.concat([df] * 2))
+            res = dd.read_hdf(os.path.join(tdir, '*.h5'), '/foo/data', chunksize=2)
+            assert res.npartitions == 2 + 2
+            tm.assert_frame_equal(res.compute(), pd.concat([df] * 2))
 
-        res = dd.read_hdf(os.path.join(tdir, '*.h5'), '/*/data', chunksize=2)
-        assert res.npartitions == 2 + 2 + 2
-        tm.assert_frame_equal(res.compute(), pd.concat([df] *  3))
+            res = dd.read_hdf(os.path.join(tdir, '*.h5'), '/*/data', chunksize=2)
+            assert res.npartitions == 2 + 2 + 2
+            tm.assert_frame_equal(res.compute(), pd.concat([df] *  3))
     finally:
         shutil.rmtree(tdir)
 


### PR DESCRIPTION
Just testing against travis.ci to see if we can locate new intermittent failures