### PR TITLE
Add dask.dataframe.reset_index, and raise exception when groupby(...as_index=False) is used.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1293,6 +1293,14 @@ class DataFrame(_Frame):
         return nlargest(self, n, columns)
 
     @derived_from(pd.DataFrame)
+    def reset_index(self):
+        new_columns = ['index'] + list(self.columns)
+        reset_index = self._partition_type.reset_index
+        out = self.map_partitions(reset_index, columns=new_columns)
+        out.divisions = [None] * (self.npartitions + 1)
+        return out
+
+    @derived_from(pd.DataFrame)
     def groupby(self, key, **kwargs):
         return GroupBy(self, key, **kwargs)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1823,6 +1823,11 @@ class GroupBy(_GroupBy):
         self.index = index
         self.kwargs = kwargs
 
+        if not kwargs.get('as_index', True):
+            msg = ("The keyword argument `as_index=False` is not supported in "
+                   "dask.dataframe.groupby")
+            raise NotImplementedError(msg)
+
         if isinstance(index, list):
             for i in index:
                 if i not in df.columns:

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pandas.util.testing as tm
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal
 
 import dask
 from dask.async import get_sync
@@ -2420,3 +2421,15 @@ def test_groupby_set_index():
     ddf = dd.from_pandas(df, npartitions=2)
     assert raises(NotImplementedError,
                   lambda: ddf.groupby(df.index.month, as_index=False))
+
+
+def test_reset_index():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    res = ddf.reset_index()
+    exp = df.reset_index()
+
+    assert len(res.index.compute()) == len(exp.index)
+    assert res.columns == tuple(exp.columns)
+    assert_array_almost_equal(res.compute().values, exp.values)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2413,3 +2413,10 @@ def test_groupby_index_array():
 
     eq(df.A.groupby(df.index.month).nunique(),
        ddf.A.groupby(ddf.index.month).nunique(), check_names=False)
+
+
+def test_groupby_set_index():
+    df = tm.makeTimeDataFrame()
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert raises(NotImplementedError,
+                  lambda: ddf.groupby(df.index.month, as_index=False))


### PR DESCRIPTION
Partially closes #735