### PR TITLE
WIP: Change dask.dataframe metadata tracking

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -863,9 +863,12 @@ class Series(_Frame):
         result.dask = dsk
         result._name = _name
         result.metadata = metadata
-        result.name = metadata.name
         result.divisions = tuple(divisions)
         return result
+
+    @property
+    def name(self):
+        return self.metadata.name
 
     @property
     def _args(self):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -226,7 +226,7 @@ class _Frame(Base):
         name = self._name + '-index'
         dsk = dict(((name, i), (getattr, key, 'index'))
                    for i, key in enumerate(self._keys()))
-        return Index(merge(dsk, self.dask), name, self.metadata, self.divisions)
+        return Index(merge(dsk, self.dask), name, None, self.divisions)
 
     @property
     def known_divisions(self):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -28,10 +28,37 @@ from ..utils import (repr_long_list, IndexCallable,
                      pseudorandom, derived_from, different_seeds)
 from ..base import Base, compute, tokenize, normalize_token
 
+
 no_default = '__no_default__'
 return_scalar = '__return_scalar__'
 
 pd.computation.expressions.set_use_numexpr(False)
+
+
+def empty_like(x):
+    """Return an empty pandas dataframe or series with the same columns/name
+    and dtype. With an index with the same name and dtype"""
+    if isinstance(x, pd.DataFrame):
+        in_index = x.index
+        index = pd.Index(range(0), dtype=in_index.dtype, name=in_index.name)
+
+        out = pd.DataFrame(columns=x.columns, index=index)
+        for c, d in zip(x.columns, x.dtypes):
+            out[c] = out[c].astype(d)
+        return out
+
+    elif isinstance(x, pd.Series):
+        index = pd.Index(range(0), dtype=in_index.dtype, name=in_index.name)
+        return pd.Series(name=x.name, dtype=x.dtypes, index=x.index)
+
+    elif isinstance(x, Series):
+        index = pd.Index(range(0), name=x.index.name)
+        return pd.Series(name=x.name, index=index)
+
+    elif isinstance(x, DataFrame):
+        index = pd.Index(range(0), name=x.index.name)
+        return pd.DataFrame(columns=x.columns, index=index)
+
 
 def _concat(args, **kwargs):
     """ Generic concat operation """

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2433,3 +2433,10 @@ def test_reset_index():
     assert len(res.index.compute()) == len(exp.index)
     assert res.columns == tuple(exp.columns)
     assert_array_almost_equal(res.compute().values, exp.values)
+
+
+def test_track_index_labels():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert ddf.index.name == df.index.name


### PR DESCRIPTION
This changes how dask.dataframe tracks metadata. We now pass around empty `pd.Series` and `pd.DataFrame`. And the metadata on these corresponds to dask dataframe metadata. Along with this we get the index names, and dtypes (for DataFrame, Series, and Indexes). 


As of the writing of this PR what works is DataFrame creation with `from_pandas`. So [this new test](https://github.com/blaze/dask/compare/blaze:master...cowlicks:track-index-labels?expand=1#diff-d586024f73e79b23848cdc88b0013fffR2438) works.

We keep these empty things around as a `metadata` attribute.