### PR TITLE
Allow literals in dask.compute

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -85,22 +85,29 @@ def compute(*args, **kwargs):
     >>> compute(a, b)
     (45, 4.5)
     """
-    groups = groupby(attrgetter('_optimize'), args)
+    variables = [a for a in args if isinstance(a, Base)]
+    groups = groupby(attrgetter('_optimize'), variables)
+
     get = kwargs.pop('get', None) or _globals['get']
 
     if not get:
-        get = args[0]._default_get
-        if not all(a._default_get == get for a in args):
+        get = variables[0]._default_get
+        if not all(a._default_get == get for a in variables):
             raise ValueError("Compute called on multiple collections with "
                              "differing default schedulers. Please specify a "
                              "scheduler `get` function using either "
                              "the `get` kwarg or globally with `set_options`.")
 
-    dsk = merge([opt(merge([v.dask for v in val]), [v._keys() for v in val])
+    dsk = merge([opt(merge([v.dask for v in val]),
+                     [v._keys() for v in val])
                 for opt, val in groups.items()])
-    keys = [arg._keys() for arg in args]
+    keys = [var._keys() for var in variables]
     results = get(dsk, keys, **kwargs)
-    return tuple(a._finalize(a, r) for a, r in zip(args, results))
+
+    results_iter = iter(results)
+    return tuple(a if not isinstance(a, Base)
+                   else a._finalize(a, next(results_iter))
+                   for a in args)
 
 
 def visualize(*args, **kwargs):

--- a/dask/base.py
+++ b/dask/base.py
@@ -111,6 +111,7 @@ def compute(*args, **kwargs):
 
 
 def visualize(*args, **kwargs):
+    args = [arg for arg in args if isinstance(arg, Base)]
     filename = kwargs.pop('filename', 'mydask')
     optimize_graph = kwargs.pop('optimize_graph', False)
     from dask.dot import dot_graph

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -7,7 +7,8 @@ pytest.importorskip('toolz')
 from toolz import compose, partial, curry
 
 import dask
-from dask.base import compute, tokenize, normalize_token, normalize_function
+from dask.base import (compute, tokenize, normalize_token, normalize_function,
+        visualize)
 from dask.utils import raises
 
 
@@ -172,5 +173,7 @@ def test_visualize():
         assert os.path.exists(os.path.join(d, 'mydask.png'))
         x.visualize(filename=os.path.join(d, 'mydask.pdf'))
         assert os.path.exists(os.path.join(d, 'mydask.pdf'))
+        visualize(x, 1, 2, filename=os.path.join(d, 'mydask.png'))
+        assert os.path.exists(os.path.join(d, 'mydask.png'))
     finally:
         shutil.rmtree(d)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -154,6 +154,15 @@ def test_compute_array_bag():
     assert bb == [1, 2, 3]
 
 
+def test_compute_with_literal():
+    x = da.arange(5, chunks=2)
+    y = 10
+
+    xx, yy = compute(x, y)
+    assert (xx == x.compute()).all()
+    assert yy == y
+
+
 def test_visualize():
     pytest.importorskip('graphviz')
     try:


### PR DESCRIPTION
This allows for non-collections in calls to dask.base.compute

    >>> compute(my_dask_array, 10)

Not sure if we actively want this or not.  It came up in a problem but I can work around it externally to dask if that's preferable.  CC @jcrist 