### PR TITLE
Replace infer_header with pandas logic

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -142,8 +142,11 @@ def fill_kwargs(fn, **kwargs):
 
     if 'names' not in kwargs:
         kwargs['names'] = csv_names(fn, **kwargs)
-    if 'header' not in kwargs:
-        kwargs['header'] = 0 if infer_header(fn, **kwargs) else None
+        if 'header' not in kwargs:
+            kwargs['header'] = 0
+    else:
+        if 'header' not in kwargs:
+            kwargs['header'] = None
 
     kwargs = clean_kwargs(kwargs)
     try:
@@ -214,27 +217,6 @@ def read_csv(fn, **kwargs):
         result = result.set_index(index)
 
     return result
-
-
-def infer_header(fn, **kwargs):
-    """ Guess if csv file has a header or not
-
-    This uses Pandas to read a sample of the file, then looks at the column
-    names to see if they are all phrase-like (words, potentially with spaces
-    in between.)
-
-    Returns True or False
-    """
-    # See read_csv docs for header for reasoning
-    kwargs.update(dict(nrows=5, names=None, parse_dates=None))
-    try:
-        df = pd.read_csv(fn, **kwargs)
-    except StopIteration:
-        kwargs['nrows'] = None
-        df = pd.read_csv(fn, **kwargs)
-    return (len(df) > 0 and
-            all(re.match('^\s*\D[\w ]*\s*$', n) for n in df.columns) and
-            not all(dt == 'O' for dt in df.dtypes))
 
 
 def csv_names(fn, encoding='utf-8', compression=None, names=None,

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -15,7 +15,7 @@ import threading
 import dask.array as da
 import dask.dataframe as dd
 from dask.dataframe.io import (read_csv, file_size,  dataframe_from_ctable,
-        from_array, from_bcolz, infer_header, from_dask_array)
+        from_array, from_bcolz, from_dask_array)
 from dask.compatibility import StringIO
 
 from dask.utils import filetext, tmpfile, ignoring
@@ -96,13 +96,6 @@ def test_consistent_dtypes():
     with filetext(text) as fn:
         df = dd.read_csv(fn, chunkbytes=30)
         assert isinstance(df.amount.sum().compute(), float)
-
-
-def test_infer_header():
-    with filetext('name,val\nAlice,100\nNA,200') as fn:
-        assert infer_header(fn) == True
-    with filetext('Alice,100\nNA,200') as fn:
-        assert infer_header(fn) == False
 
 
 def eq(a, b):
@@ -819,7 +812,7 @@ def test_read_hdf_doesnt_segfault():
 
 
 def test_read_csv_header_issue_823():
-    text = '''a b c\n1 2 3\n4 5 6'''.replace(' ', '\t')
+    text = '''a b c-d\n1 2 3\n4 5 6'''.replace(' ', '\t')
     with filetext(text) as fn:
         df = dd.read_csv(fn, sep='\t')
         eq(df, pd.read_csv(fn, sep='\t'))


### PR DESCRIPTION
Previously we used a heuristic to determine if the CSV file had a
header or not.  Now we replicate the logic followed by pandas, which
ends up being significantly simpler.

cc @DSLituiev

```python
In [1]: !cat foo.csv
SNP	gene	beta	t-stat	p-value	FDR
chr22:24383284	GSTT1	0.41578429979963	12.4829821462724	1.51422020504144e-17	6.32523496271855e-12
chr22:24372116	GSTT2	0.421553200793657	12.4382517630312	1.74998788547579e-17	6.32523496271855e-12
chr22:24346258	GSTT3	0.512315241744027	10.2518229631821	2.81456935069628e-14	6.78207074451829e-09


In [2]: import dask.dataframe as dd

In [3]: df = dd.read_csv('foo.csv', sep='\t')

In [4]: df.compute()
Out[4]: 
              SNP   gene      beta     t-stat       p-value           FDR
0  chr22:24383284  GSTT1  0.415784  12.482982  1.514220e-17  6.325235e-12
1  chr22:24372116  GSTT2  0.421553  12.438252  1.749988e-17  6.325235e-12
2  chr22:24346258  GSTT3  0.512315  10.251823  2.814569e-14  6.782071e-09
```