### PR TITLE
Use uuid to tokenize unknown types

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -141,11 +141,16 @@ def normalize_function(func):
 
 
 normalize_token = Dispatch()
-normalize_token.register((int, float, str, unicode, bytes, tuple, list,
-                         type(None)),
+normalize_token.register((int, float, str, unicode, bytes, type(None)),
                          identity)
-normalize_token.register(dict, lambda a: tuple(sorted(a.items())))
 
+@partial(normalize_token.register, dict)
+def normalize_dict(d):
+    return normalize_token(sorted(d.items()))
+
+@partial(normalize_token.register, (tuple, list, set))
+def normalize_seq(seq):
+    return type(seq), list(map(normalize_token, seq))
 
 @partial(normalize_token.register, object)
 def normalize_object(o):

--- a/dask/base.py
+++ b/dask/base.py
@@ -227,7 +227,7 @@ def tokenize(*args, **kwargs):
     """ Deterministic token
 
     >>> tokenize([1, 2, '3'])
-    '9d71491b50023b06fc76928e6eddb952'
+    '7d6a880cd9ec03506eee6973ff551339'
 
     >>> tokenize('Hello') == tokenize('Hello')
     True

--- a/dask/base.py
+++ b/dask/base.py
@@ -142,7 +142,8 @@ def normalize_function(func):
 
 
 normalize_token = Dispatch()
-normalize_token.register((int, float, str, unicode, bytes, type(None), type),
+normalize_token.register((int, float, str, unicode, bytes, type(None), type,
+                          slice),
                          identity)
 
 @partial(normalize_token.register, dict)
@@ -158,7 +159,11 @@ def normalize_object(o):
     if callable(o):
         return normalize_function(o)
     else:
-        return str(uuid.uuid4())
+        return uuid.uuid4().hex
+
+@partial(normalize_token.register, Base)
+def normalize_base(b):
+    return type(b).__name__, b.key
 
 
 with ignoring(ImportError):
@@ -208,6 +213,7 @@ with ignoring(ImportError):
         return (data, x.dtype, x.shape, x.strides)
 
     normalize_token.register(np.dtype, repr)
+    normalize_token.register(np.generic, repr)
 
 
 with ignoring(ImportError):

--- a/dask/base.py
+++ b/dask/base.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-import warnings
-from operator import attrgetter
-from hashlib import md5
 from functools import partial
+from hashlib import md5
+from operator import attrgetter
+import os
 import uuid
+import warnings
 
 from toolz import merge, groupby, curry, identity
 from toolz.functoolz import Compose
@@ -186,6 +187,8 @@ with ignoring(ImportError):
     def normalize_array(x):
         if not x.shape:
             return (str(x), x.dtype)
+        if hasattr(x, 'mode') and hasattr(x, 'filename'):
+            return x.filename, os.path.getmtime(x.filename), x.dtype, x.shape
         if x.dtype.hasobject:
             try:
                 data = md5('-'.join(x.flat)).hexdigest()

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-import operator
+from collections import Iterator
 from functools import wraps
 from itertools import chain, count
-from collections import Iterator
+import operator
+import uuid
 
 from toolz import merge, unique, curry
 
@@ -89,9 +90,6 @@ def to_task_dasks(expr):
     return expr, []
 
 
-tokens = ('_{0}'.format(i) for i in count(1))
-
-
 def tokenize(*args, **kwargs):
     """Mapping function from task -> consistent name.
 
@@ -106,7 +104,8 @@ def tokenize(*args, **kwargs):
     """
     if kwargs.pop('pure', False):
         return base.tokenize(*args)
-    return next(tokens)
+    else:
+        return str(uuid.uuid4())
 
 
 def applyfunc(func, args, kwargs, pure=False):

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -9,7 +9,7 @@ from toolz import compose, partial, curry
 import dask
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
         visualize)
-from dask.utils import raises
+from dask.utils import raises, tmpfile
 
 
 def test_normalize():
@@ -78,6 +78,21 @@ def test_tokenize_numpy_array_on_object_dtype():
            tokenize(np.array(['a', None, 'aaa'], dtype=object))
     assert tokenize(np.array([(1, 'a'), (1, None), (1, 'aaa')], dtype=object)) == \
            tokenize(np.array([(1, 'a'), (1, None), (1, 'aaa')], dtype=object))
+
+
+def test_tokenize_numpy_memmap():
+    np = pytest.importorskip('numpy')
+    with tmpfile('.npy') as fn:
+        x = np.arange(5)
+        np.save(fn, x)
+        y = tokenize(np.load(fn, mmap_mode='r'))
+
+    with tmpfile('.npy') as fn:
+        x = np.arange(5)
+        np.save(fn, x)
+        z = tokenize(np.load(fn, mmap_mode='r'))
+
+    assert y != z
 
 
 def test_tokenize_pandas():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -58,7 +58,9 @@ def test_tokenize_numpy_datetime():
 
 def test_tokenize_numpy_scalar():
     np = pytest.importorskip('numpy')
-    tokenize(np.array(1.0, dtype='f8'))
+    assert tokenize(np.array(1.0, dtype='f8')) == tokenize(np.array(1.0, dtype='f8'))
+    assert (tokenize(np.array([(1, 2)], dtype=[('a', 'i4'), ('b', 'i8')])[0])
+         == tokenize(np.array([(1, 2)], dtype=[('a', 'i4'), ('b', 'i8')])[0]))
 
 
 def test_tokenize_numpy_array_on_object_dtype():
@@ -87,7 +89,7 @@ def test_tokenize_numpy_memmap():
 
 
 def test_normalize_base():
-    for i in [1, 1.1, '1']:
+    for i in [1, 1.1, '1', slice(1, 2, 3)]:
         assert normalize_token(i) is i
 
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -9,7 +9,7 @@ from toolz import compose, partial, curry
 import dask
 from dask.base import (compute, tokenize, normalize_token, normalize_function,
         visualize)
-from dask.utils import raises, tmpfile
+from dask.utils import raises, tmpfile, ignoring
 
 
 def test_normalize_function():
@@ -127,11 +127,23 @@ def test_tokenize_same_repr():
 def test_tokenize_sequences():
     assert tokenize([1]) != tokenize([2])
     assert tokenize([1]) != tokenize((1,))
+    assert tokenize([1]) == tokenize([1])
 
     x = np.arange(2000)  # long enough to drop information in repr
     y = np.arange(2000)
     y[1000] = 0  # middle isn't printed in repr
     assert tokenize([x]) != tokenize([y])
+
+
+def test_tokenize_ordered_dict():
+    with ignoring(ImportError):
+        from collections import OrderedDict
+        a = OrderedDict([('a', 1), ('b', 2)])
+        b = OrderedDict([('a', 1), ('b', 2)])
+        c = OrderedDict([('b', 2), ('a', 1)])
+
+        assert tokenize(a) == tokenize(b)
+        assert tokenize(a) != tokenize(c)
 
 
 da = pytest.importorskip('dask.array')

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -102,6 +102,17 @@ def test_tokenize_kwargs():
     assert tokenize(5, x=1) != tokenize(5, x=2)
     assert tokenize(5, x=1) != tokenize(5, y=1)
 
+
+def test_tokenize_same_repr():
+    class Foo(object):
+        def __init__(self, x):
+            self.x = x
+        def __repr__(self):
+            return 'a foo'
+
+    assert tokenize(Foo(1)) != tokenize(Foo(2))
+
+
 da = pytest.importorskip('dask.array')
 import numpy as np
 


### PR DESCRIPTION
Fixes #829

Previously we used `repr` as a catch-all for tokenize.  This failed
when different objects repred identically.  Now we default to random
uuids.  This requires us to be more diligent in the simple case but
makes us much more conservative about avoiding collisions.

cc @rabernat @shoyer @jcrist 