### PR TITLE
Add environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: dask
+dependencies:
+- python
+- toolz
+- numpy
+- pandas
+- dill
+- partd
+- chest
+- pytest


### PR DESCRIPTION
This lets users set up a dask development environment easily.
To test this:
```bash
$ cd dask/
$ conda env create
$ source activate dask  # You should change the env name in the environment.yaml file if you alread have a "dask" environment.
$ python setup.py develop
$ py.test
```
Currently `dask/tests/test_multiprocessing.py::test_unpicklable_result_generate_errors` fails. I'll fix this tomorrow.