### PR TITLE
Tree reductions for dask.array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -993,14 +993,14 @@ class Array(Base):
         return max(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
 
     @wraps(np.argmin)
-    def argmin(self, axis=None):
+    def argmin(self, axis=None, max_leaves=None):
         from .reductions import argmin
-        return argmin(self, axis=axis)
+        return argmin(self, axis=axis, max_leaves=max_leaves)
 
     @wraps(np.argmax)
-    def argmax(self, axis=None):
+    def argmax(self, axis=None, max_leaves=None):
         from .reductions import argmax
-        return argmax(self, axis=axis)
+        return argmax(self, axis=axis, max_leaves=max_leaves)
 
     @wraps(np.sum)
     def sum(self, axis=None, dtype=None, keepdims=False, max_leaves=None):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1021,16 +1021,19 @@ class Array(Base):
                     max_leaves=max_leaves)
 
     @wraps(np.std)
-    def std(self, axis=None, dtype=None, keepdims=False, ddof=0):
+    def std(self, axis=None, dtype=None, keepdims=False, ddof=0, max_leaves=None):
         from .reductions import std
-        return std(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof)
+        return std(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof,
+                   max_leaves=max_leaves)
 
     @wraps(np.var)
-    def var(self, axis=None, dtype=None, keepdims=False, ddof=0):
+    def var(self, axis=None, dtype=None, keepdims=False, ddof=0, max_leaves=None):
         from .reductions import var
-        return var(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof)
+        return var(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof,
+                   max_leaves=max_leaves)
 
-    def moment(self, order, axis=None, dtype=None, keepdims=False, ddof=0):
+    def moment(self, order, axis=None, dtype=None, keepdims=False, ddof=0,
+               max_leaves=None):
         """Calculate the nth centralized moment.
 
         Parameters
@@ -1067,7 +1070,7 @@ class Array(Base):
 
         from .reductions import moment
         return moment(self, order, axis=axis, dtype=dtype, keepdims=keepdims,
-                      ddof=ddof)
+                      ddof=ddof, max_leaves=max_leaves)
 
     def vnorm(self, ord=None, axis=None, keepdims=False, max_leaves=None):
         """ Vector norm """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -973,67 +973,67 @@ class Array(Base):
         return elemwise(operator.xor, other, self)
 
     @wraps(np.any)
-    def any(self, axis=None, keepdims=False, max_leaves=None):
+    def any(self, axis=None, keepdims=False, split_threshold=None):
         from .reductions import any
-        return any(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
+        return any(self, axis=axis, keepdims=keepdims, split_threshold=split_threshold)
 
     @wraps(np.all)
-    def all(self, axis=None, keepdims=False, max_leaves=None):
+    def all(self, axis=None, keepdims=False, split_threshold=None):
         from .reductions import all
-        return all(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
+        return all(self, axis=axis, keepdims=keepdims, split_threshold=split_threshold)
 
     @wraps(np.min)
-    def min(self, axis=None, keepdims=False, max_leaves=None):
+    def min(self, axis=None, keepdims=False, split_threshold=None):
         from .reductions import min
-        return min(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
+        return min(self, axis=axis, keepdims=keepdims, split_threshold=split_threshold)
 
     @wraps(np.max)
-    def max(self, axis=None, keepdims=False, max_leaves=None):
+    def max(self, axis=None, keepdims=False, split_threshold=None):
         from .reductions import max
-        return max(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
+        return max(self, axis=axis, keepdims=keepdims, split_threshold=split_threshold)
 
     @wraps(np.argmin)
-    def argmin(self, axis=None, max_leaves=None):
+    def argmin(self, axis=None, split_threshold=None):
         from .reductions import argmin
-        return argmin(self, axis=axis, max_leaves=max_leaves)
+        return argmin(self, axis=axis, split_threshold=split_threshold)
 
     @wraps(np.argmax)
-    def argmax(self, axis=None, max_leaves=None):
+    def argmax(self, axis=None, split_threshold=None):
         from .reductions import argmax
-        return argmax(self, axis=axis, max_leaves=max_leaves)
+        return argmax(self, axis=axis, split_threshold=split_threshold)
 
     @wraps(np.sum)
-    def sum(self, axis=None, dtype=None, keepdims=False, max_leaves=None):
+    def sum(self, axis=None, dtype=None, keepdims=False, split_threshold=None):
         from .reductions import sum
         return sum(self, axis=axis, dtype=dtype, keepdims=keepdims,
-                   max_leaves=max_leaves)
+                   split_threshold=split_threshold)
 
     @wraps(np.prod)
-    def prod(self, axis=None, dtype=None, keepdims=False, max_leaves=None):
+    def prod(self, axis=None, dtype=None, keepdims=False, split_threshold=None):
         from .reductions import prod
         return prod(self, axis=axis, dtype=dtype, keepdims=keepdims,
-                    max_leaves=max_leaves)
+                    split_threshold=split_threshold)
 
     @wraps(np.mean)
-    def mean(self, axis=None, dtype=None, keepdims=False, max_leaves=None):
+    def mean(self, axis=None, dtype=None, keepdims=False, split_threshold=None):
         from .reductions import mean
         return mean(self, axis=axis, dtype=dtype, keepdims=keepdims,
-                    max_leaves=max_leaves)
+                    split_threshold=split_threshold)
 
     @wraps(np.std)
-    def std(self, axis=None, dtype=None, keepdims=False, ddof=0, max_leaves=None):
+    def std(self, axis=None, dtype=None, keepdims=False, ddof=0, split_threshold=None):
         from .reductions import std
         return std(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof,
-                   max_leaves=max_leaves)
+                   split_threshold=split_threshold)
 
     @wraps(np.var)
-    def var(self, axis=None, dtype=None, keepdims=False, ddof=0, max_leaves=None):
+    def var(self, axis=None, dtype=None, keepdims=False, ddof=0, split_threshold=None):
         from .reductions import var
         return var(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof,
-                   max_leaves=max_leaves)
+                   split_threshold=split_threshold)
 
     def moment(self, order, axis=None, dtype=None, keepdims=False, ddof=0,
-               max_leaves=None):
+               split_threshold=None):
         """Calculate the nth centralized moment.
 
         Parameters
@@ -1070,13 +1070,13 @@ class Array(Base):
 
         from .reductions import moment
         return moment(self, order, axis=axis, dtype=dtype, keepdims=keepdims,
-                      ddof=ddof, max_leaves=max_leaves)
+                      ddof=ddof, split_threshold=split_threshold)
 
-    def vnorm(self, ord=None, axis=None, keepdims=False, max_leaves=None):
+    def vnorm(self, ord=None, axis=None, keepdims=False, split_threshold=None):
         """ Vector norm """
         from .reductions import vnorm
         return vnorm(self, ord=ord, axis=axis, keepdims=keepdims,
-                     max_leaves=max_leaves)
+                     split_threshold=split_threshold)
 
     @wraps(map_blocks)
     def map_blocks(self, func, chunks=None, dtype=None, name=None):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -973,24 +973,24 @@ class Array(Base):
         return elemwise(operator.xor, other, self)
 
     @wraps(np.any)
-    def any(self, axis=None, keepdims=False):
+    def any(self, axis=None, keepdims=False, max_leaves=None):
         from .reductions import any
-        return any(self, axis=axis, keepdims=keepdims)
+        return any(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
 
     @wraps(np.all)
-    def all(self, axis=None, keepdims=False):
+    def all(self, axis=None, keepdims=False, max_leaves=None):
         from .reductions import all
-        return all(self, axis=axis, keepdims=keepdims)
+        return all(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
 
     @wraps(np.min)
-    def min(self, axis=None, keepdims=False):
+    def min(self, axis=None, keepdims=False, max_leaves=None):
         from .reductions import min
-        return min(self, axis=axis, keepdims=keepdims)
+        return min(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
 
     @wraps(np.max)
-    def max(self, axis=None, keepdims=False):
+    def max(self, axis=None, keepdims=False, max_leaves=None):
         from .reductions import max
-        return max(self, axis=axis, keepdims=keepdims)
+        return max(self, axis=axis, keepdims=keepdims, max_leaves=max_leaves)
 
     @wraps(np.argmin)
     def argmin(self, axis=None):
@@ -1003,19 +1003,22 @@ class Array(Base):
         return argmax(self, axis=axis)
 
     @wraps(np.sum)
-    def sum(self, axis=None, dtype=None, keepdims=False):
+    def sum(self, axis=None, dtype=None, keepdims=False, max_leaves=None):
         from .reductions import sum
-        return sum(self, axis=axis, dtype=dtype, keepdims=keepdims)
+        return sum(self, axis=axis, dtype=dtype, keepdims=keepdims,
+                   max_leaves=max_leaves)
 
     @wraps(np.prod)
-    def prod(self, axis=None, dtype=None, keepdims=False):
+    def prod(self, axis=None, dtype=None, keepdims=False, max_leaves=None):
         from .reductions import prod
-        return prod(self, axis=axis, dtype=dtype, keepdims=keepdims)
+        return prod(self, axis=axis, dtype=dtype, keepdims=keepdims,
+                    max_leaves=max_leaves)
 
     @wraps(np.mean)
-    def mean(self, axis=None, dtype=None, keepdims=False):
+    def mean(self, axis=None, dtype=None, keepdims=False, max_leaves=None):
         from .reductions import mean
-        return mean(self, axis=axis, dtype=dtype, keepdims=keepdims)
+        return mean(self, axis=axis, dtype=dtype, keepdims=keepdims,
+                    max_leaves=max_leaves)
 
     @wraps(np.std)
     def std(self, axis=None, dtype=None, keepdims=False, ddof=0):
@@ -1063,12 +1066,14 @@ class Array(Base):
         """
 
         from .reductions import moment
-        return moment(self, order, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof)
+        return moment(self, order, axis=axis, dtype=dtype, keepdims=keepdims,
+                      ddof=ddof)
 
-    def vnorm(self, ord=None, axis=None, keepdims=False):
+    def vnorm(self, ord=None, axis=None, keepdims=False, max_leaves=None):
         """ Vector norm """
         from .reductions import vnorm
-        return vnorm(self, ord=ord, axis=axis, keepdims=keepdims)
+        return vnorm(self, ord=ord, axis=axis, keepdims=keepdims,
+                     max_leaves=max_leaves)
 
     @wraps(map_blocks)
     def map_blocks(self, func, chunks=None, dtype=None, name=None):

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -12,6 +12,7 @@ from .core import _concatenate2, Array, atop, sqrt, lol_tuples
 from .numpy_compat import divide
 from ..compatibility import getargspec, builtins
 from ..base import tokenize
+from ..context import _globals
 from ..utils import ignoring
 
 
@@ -32,11 +33,12 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None,
     if dtype and 'dtype' in getargspec(aggregate).args:
         aggregate = partial(aggregate, dtype=dtype)
 
-    # Normalize axes
+    # Normalize split_threshold
+    split_threshold = split_threshold or _globals.get('split_threshold', 32)
     if isinstance(split_threshold, dict):
         split_threshold = dict((k, split_threshold.get(k, 2)) for k in axis)
     elif isinstance(split_threshold, int):
-        n = builtins.max(int(split_threshold ** (1/len(axis))), 2)
+        n = builtins.max(int(split_threshold ** (1/(len(axis) or 1))), 2)
         split_threshold = dict.fromkeys(axis, n)
     else:
         split_threshold = dict((k, v) for (k, v) in enumerate(x.numblocks) if k in axis)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -58,9 +58,9 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None,
         tmp = partial_reduce(func, tmp, split_threshold, True, None)
     func = compose(partial(aggregate, axis=axis, keepdims=keepdims),
                    partial(_concatenate2, axes=axis))
-    return partial_reduce(func, tmp, split_threshold, keepdims=keepdims, dtype=dtype,
-                          name=('reduce-' + tokenize(func, x, keepdims, dtype)))
-
+    return partial_reduce(func, tmp, split_threshold, keepdims=keepdims,
+                          dtype=dtype)
+                          
 
 def partial_reduce(func, x, split_threshold, keepdims=False, dtype=None, name=None):
     """Partial reduction across multiple axes.

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -498,6 +498,13 @@ def test_norm():
     assert eq(b.vnorm(ord=1), np.linalg.norm(a.flatten(), ord=1))
     assert eq(b.vnorm(ord=4, axis=0), np.linalg.norm(a, ord=4, axis=0))
     assert b.vnorm(ord=4, axis=0, keepdims=True).ndim == b.ndim
+    max_leaves = {0: 3, 1: 3}
+    assert eq(b.vnorm(ord=1, axis=0, max_leaves=max_leaves),
+              np.linalg.norm(a, ord=1, axis=0))
+    assert eq(b.vnorm(ord=np.inf, axis=0, max_leaves=max_leaves),
+              np.linalg.norm(a, ord=np.inf, axis=0))
+    assert eq(b.vnorm(ord=np.inf, max_leaves=max_leaves),
+              np.linalg.norm(a.flatten(), ord=np.inf))
 
 
 def test_choose():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -498,12 +498,12 @@ def test_norm():
     assert eq(b.vnorm(ord=1), np.linalg.norm(a.flatten(), ord=1))
     assert eq(b.vnorm(ord=4, axis=0), np.linalg.norm(a, ord=4, axis=0))
     assert b.vnorm(ord=4, axis=0, keepdims=True).ndim == b.ndim
-    max_leaves = {0: 3, 1: 3}
-    assert eq(b.vnorm(ord=1, axis=0, max_leaves=max_leaves),
+    split_threshold = {0: 3, 1: 3}
+    assert eq(b.vnorm(ord=1, axis=0, split_threshold=split_threshold),
               np.linalg.norm(a, ord=1, axis=0))
-    assert eq(b.vnorm(ord=np.inf, axis=0, max_leaves=max_leaves),
+    assert eq(b.vnorm(ord=np.inf, axis=0, split_threshold=split_threshold),
               np.linalg.norm(a, ord=np.inf, axis=0))
-    assert eq(b.vnorm(ord=np.inf, max_leaves=max_leaves),
+    assert eq(b.vnorm(ord=np.inf, split_threshold=split_threshold),
               np.linalg.norm(a.flatten(), ord=np.inf))
 
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -287,10 +287,3 @@ def test_tree_reduce_depth():
     d3 = o.dask[d2[1][0]]
     assert len(d3[1]) == 2
     assert all(i[0].startswith('atop') for i in d3[1])
-
-
-def test_partial_reduce_names():
-    x = da.from_array(np.arange(242).reshape((11, 22)), chunks=(3, 4))
-    assert x.sum(axis=0).name == x.sum(axis=0, split_threshold=3).name
-    assert x.sum(axis=1).name == x.sum(axis=1, split_threshold=3).name
-    assert x.sum().name == x.sum(split_threshold=3).name

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -36,7 +36,7 @@ def test_arg_reduction():
     assert eq(result, np.array([101, 11, 103]))
 
 
-def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True):
+def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, max_leaves=None):
     assert eq(da_func(darr), np_func(narr))
     assert eq(da_func(darr, keepdims=True), np_func(narr, keepdims=True))
     assert same_keys(da_func(darr), da_func(darr))
@@ -45,30 +45,35 @@ def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True):
         assert eq(da_func(darr, dtype='f8'), np_func(narr, dtype='f8'))
         assert eq(da_func(darr, dtype='i8'), np_func(narr, dtype='i8'))
         assert same_keys(da_func(darr, dtype='i8'), da_func(darr, dtype='i8'))
+    if max_leaves:
+        assert eq(da_func(darr, max_leaves=max_leaves), np_func(narr))
+        assert eq(da_func(darr, keepdims=True, max_leaves=max_leaves),
+                  np_func(narr, keepdims=True))
 
 
 def test_reductions_1D_float():
     x = np.arange(5).astype('f4')
     a = da.from_array(x, chunks=(2,))
+    max_leaves = {0: 2}
 
-    reduction_1d_test(da.sum, a, np.sum, x)
-    reduction_1d_test(da.prod, a, np.prod, x)
-    reduction_1d_test(da.mean, a, np.mean, x)
+    reduction_1d_test(da.sum, a, np.sum, x, max_leaves=max_leaves)
+    reduction_1d_test(da.prod, a, np.prod, x, max_leaves=max_leaves)
+    reduction_1d_test(da.mean, a, np.mean, x, max_leaves=max_leaves)
     reduction_1d_test(da.var, a, np.var, x)
     reduction_1d_test(da.std, a, np.std, x)
-    reduction_1d_test(da.min, a, np.min, x, False)
-    reduction_1d_test(da.max, a, np.max, x, False)
-    reduction_1d_test(da.any, a, np.any, x, False)
-    reduction_1d_test(da.all, a, np.all, x, False)
+    reduction_1d_test(da.min, a, np.min, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.max, a, np.max, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.any, a, np.any, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.all, a, np.all, x, False, max_leaves=max_leaves)
 
-    reduction_1d_test(da.nansum, a, np.nansum, x)
+    reduction_1d_test(da.nansum, a, np.nansum, x, max_leaves=max_leaves)
     with ignoring(AttributeError):
-        reduction_1d_test(da.nanprod, a, np.nanprod, x)
-    reduction_1d_test(da.nanmean, a, np.mean, x)
+        reduction_1d_test(da.nanprod, a, np.nanprod, x, max_leaves=max_leaves)
+    reduction_1d_test(da.nanmean, a, np.mean, x, max_leaves=max_leaves)
     reduction_1d_test(da.nanvar, a, np.var, x)
     reduction_1d_test(da.nanstd, a, np.std, x)
-    reduction_1d_test(da.nanmin, a, np.nanmin, x, False)
-    reduction_1d_test(da.nanmax, a, np.nanmax, x, False)
+    reduction_1d_test(da.nanmin, a, np.nanmin, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.nanmax, a, np.nanmax, x, False, max_leaves=max_leaves)
 
     assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
     assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
@@ -79,25 +84,26 @@ def test_reductions_1D_float():
 def test_reductions_1D_int():
     x = np.arange(5).astype('i4')
     a = da.from_array(x, chunks=(2,))
+    max_leaves = {0: 2}
 
-    reduction_1d_test(da.sum, a, np.sum, x)
-    reduction_1d_test(da.prod, a, np.prod, x)
-    reduction_1d_test(da.mean, a, np.mean, x)
+    reduction_1d_test(da.sum, a, np.sum, x, max_leaves=max_leaves)
+    reduction_1d_test(da.prod, a, np.prod, x, max_leaves=max_leaves)
+    reduction_1d_test(da.mean, a, np.mean, x, max_leaves=max_leaves)
     reduction_1d_test(da.var, a, np.var, x)
     reduction_1d_test(da.std, a, np.std, x)
-    reduction_1d_test(da.min, a, np.min, x, False)
-    reduction_1d_test(da.max, a, np.max, x, False)
-    reduction_1d_test(da.any, a, np.any, x, False)
-    reduction_1d_test(da.all, a, np.all, x, False)
+    reduction_1d_test(da.min, a, np.min, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.max, a, np.max, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.any, a, np.any, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.all, a, np.all, x, False, max_leaves=max_leaves)
 
-    reduction_1d_test(da.nansum, a, np.nansum, x)
+    reduction_1d_test(da.nansum, a, np.nansum, x, max_leaves=max_leaves)
     with ignoring(AttributeError):
-        reduction_1d_test(da.nanprod, a, np.nanprod, x)
-    reduction_1d_test(da.nanmean, a, np.mean, x)
+        reduction_1d_test(da.nanprod, a, np.nanprod, x, max_leaves=max_leaves)
+    reduction_1d_test(da.nanmean, a, np.mean, x, max_leaves=max_leaves)
     reduction_1d_test(da.nanvar, a, np.var, x)
     reduction_1d_test(da.nanstd, a, np.std, x)
-    reduction_1d_test(da.nanmin, a, np.nanmin, x, False)
-    reduction_1d_test(da.nanmax, a, np.nanmax, x, False)
+    reduction_1d_test(da.nanmin, a, np.nanmin, x, False, max_leaves=max_leaves)
+    reduction_1d_test(da.nanmax, a, np.nanmax, x, False, max_leaves=max_leaves)
 
     assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
     assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
@@ -105,7 +111,8 @@ def test_reductions_1D_int():
     assert eq(da.nanargmin(a, axis=0), np.nanargmin(x, axis=0))
 
 
-def reduction_2d_test(da_func, darr, np_func, narr, use_dtype=True):
+def reduction_2d_test(da_func, darr, np_func, narr, use_dtype=True,
+                      max_leaves=None):
     assert eq(da_func(darr), np_func(narr))
     assert eq(da_func(darr, keepdims=True), np_func(narr, keepdims=True))
     assert eq(da_func(darr, axis=0), np_func(narr, axis=0))
@@ -121,32 +128,44 @@ def reduction_2d_test(da_func, darr, np_func, narr, use_dtype=True):
         assert eq(da_func(darr, dtype='f8'), np_func(narr, dtype='f8'))
         assert eq(da_func(darr, dtype='i8'), np_func(narr, dtype='i8'))
 
+    if max_leaves:
+        assert eq(da_func(darr, max_leaves=max_leaves), np_func(narr))
+        assert eq(da_func(darr, keepdims=True, max_leaves=max_leaves),
+                  np_func(narr, keepdims=True))
+        assert eq(da_func(darr, axis=0, max_leaves=max_leaves), np_func(narr, axis=0))
+        assert eq(da_func(darr, axis=0, keepdims=True, max_leaves=max_leaves),
+                  np_func(narr, axis=0, keepdims=True))
+        assert eq(da_func(darr, axis=1, max_leaves=max_leaves), np_func(narr, axis=1))
+        assert eq(da_func(darr, axis=1, keepdims=True, max_leaves=max_leaves),
+                  np_func(narr, axis=1, keepdims=True))
+
 
 def test_reductions_2D_float():
     x = np.arange(1, 122).reshape((11, 11)).astype('f4')
     a = da.from_array(x, chunks=(4, 4))
+    max_leaves = {0: 2, 1: 2}
 
     b = a.sum(keepdims=True)
     assert b._keys() == [[(b.name, 0, 0)]]
 
-    reduction_2d_test(da.sum, a, np.sum, x)
-    reduction_2d_test(da.prod, a, np.prod, x)
-    reduction_2d_test(da.mean, a, np.mean, x)
+    reduction_2d_test(da.sum, a, np.sum, x, max_leaves=max_leaves)
+    reduction_2d_test(da.prod, a, np.prod, x, max_leaves=max_leaves)
+    reduction_2d_test(da.mean, a, np.mean, x, max_leaves=max_leaves)
     reduction_2d_test(da.var, a, np.var, x, False)  # Difference in dtype algo
     reduction_2d_test(da.std, a, np.std, x, False)  # Difference in dtype algo
-    reduction_2d_test(da.min, a, np.min, x, False)
-    reduction_2d_test(da.max, a, np.max, x, False)
-    reduction_2d_test(da.any, a, np.any, x, False)
-    reduction_2d_test(da.all, a, np.all, x, False)
+    reduction_2d_test(da.min, a, np.min, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.max, a, np.max, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.any, a, np.any, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.all, a, np.all, x, False, max_leaves=max_leaves)
 
-    reduction_2d_test(da.nansum, a, np.nansum, x)
+    reduction_2d_test(da.nansum, a, np.nansum, x, max_leaves=max_leaves)
     with ignoring(AttributeError):
-        reduction_2d_test(da.nanprod, a, np.nanprod, x)
-    reduction_2d_test(da.nanmean, a, np.mean, x)
+        reduction_2d_test(da.nanprod, a, np.nanprod, x, max_leaves=max_leaves)
+    reduction_2d_test(da.nanmean, a, np.mean, x, max_leaves=max_leaves)
     reduction_2d_test(da.nanvar, a, np.nanvar, x, False)  # Difference in dtype algo
     reduction_2d_test(da.nanstd, a, np.nanstd, x, False)  # Difference in dtype algo
-    reduction_2d_test(da.nanmin, a, np.nanmin, x, False)
-    reduction_2d_test(da.nanmax, a, np.nanmax, x, False)
+    reduction_2d_test(da.nanmin, a, np.nanmin, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.nanmax, a, np.nanmax, x, False, max_leaves=max_leaves)
 
     assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
     assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
@@ -157,25 +176,26 @@ def test_reductions_2D_float():
 def test_reductions_2D_int():
     x = np.arange(1, 122).reshape((11, 11)).astype('i4')
     a = da.from_array(x, chunks=(4, 4))
+    max_leaves = {0: 2, 1: 2}
 
-    reduction_2d_test(da.sum, a, np.sum, x)
-    reduction_2d_test(da.prod, a, np.prod, x)
-    reduction_2d_test(da.mean, a, np.mean, x)
+    reduction_2d_test(da.sum, a, np.sum, x, max_leaves=max_leaves)
+    reduction_2d_test(da.prod, a, np.prod, x, max_leaves=max_leaves)
+    reduction_2d_test(da.mean, a, np.mean, x, max_leaves=max_leaves)
     reduction_2d_test(da.var, a, np.var, x, False)  # Difference in dtype algo
     reduction_2d_test(da.std, a, np.std, x, False)  # Difference in dtype algo
-    reduction_2d_test(da.min, a, np.min, x, False)
-    reduction_2d_test(da.max, a, np.max, x, False)
-    reduction_2d_test(da.any, a, np.any, x, False)
-    reduction_2d_test(da.all, a, np.all, x, False)
+    reduction_2d_test(da.min, a, np.min, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.max, a, np.max, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.any, a, np.any, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.all, a, np.all, x, False, max_leaves=max_leaves)
 
-    reduction_2d_test(da.nansum, a, np.nansum, x)
+    reduction_2d_test(da.nansum, a, np.nansum, x, max_leaves=max_leaves)
     with ignoring(AttributeError):
-        reduction_2d_test(da.nanprod, a, np.nanprod, x)
-    reduction_2d_test(da.nanmean, a, np.mean, x)
+        reduction_2d_test(da.nanprod, a, np.nanprod, x, max_leaves=max_leaves)
+    reduction_2d_test(da.nanmean, a, np.mean, x, max_leaves=max_leaves)
     reduction_2d_test(da.nanvar, a, np.nanvar, x, False)  # Difference in dtype algo
     reduction_2d_test(da.nanstd, a, np.nanstd, x, False)  # Difference in dtype algo
-    reduction_2d_test(da.nanmin, a, np.nanmin, x, False)
-    reduction_2d_test(da.nanmax, a, np.nanmax, x, False)
+    reduction_2d_test(da.nanmin, a, np.nanmin, x, False, max_leaves=max_leaves)
+    reduction_2d_test(da.nanmax, a, np.nanmax, x, False, max_leaves=max_leaves)
 
     assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
     assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -5,7 +5,6 @@ pytest.importorskip('numpy')
 
 import dask.array as da
 from dask.utils import ignoring
-from dask.array.reductions import arg_aggregate
 import numpy as np
 
 
@@ -27,13 +26,6 @@ def same_keys(a, b):
         else:
             return k
     return sorted(a.dask, key=key) == sorted(b.dask, key=key)
-
-
-def test_arg_reduction():
-    pairs = [([4, 3, 5], [10, 11, 12]),
-             ([3, 5, 1], [1, 2, 3])]
-    result = arg_aggregate(np.min, np.argmin, (100, 100), pairs)
-    assert eq(result, np.array([101, 11, 103]))
 
 
 def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, max_leaves=True):
@@ -83,6 +75,11 @@ def test_reductions_1D(dtype):
     assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
     assert eq(da.nanargmax(a, axis=0), np.nanargmax(x, axis=0))
     assert eq(da.nanargmin(a, axis=0), np.nanargmin(x, axis=0))
+
+    assert eq(da.argmax(a, axis=0, max_leaves=2), np.argmax(x, axis=0))
+    assert eq(da.argmin(a, axis=0, max_leaves=2), np.argmin(x, axis=0))
+    assert eq(da.nanargmax(a, axis=0, max_leaves=2), np.nanargmax(x, axis=0))
+    assert eq(da.nanargmin(a, axis=0, max_leaves=2), np.nanargmin(x, axis=0))
 
 
 def reduction_2d_test(da_func, darr, np_func, narr, use_dtype=True,
@@ -154,6 +151,15 @@ def test_reductions_2D(dtype):
     assert eq(da.nanargmax(a, axis=1), np.nanargmax(x, axis=1))
     assert eq(da.nanargmin(a, axis=1), np.nanargmin(x, axis=1))
 
+    assert eq(da.argmax(a, axis=0, max_leaves=2), np.argmax(x, axis=0))
+    assert eq(da.argmin(a, axis=0, max_leaves=2), np.argmin(x, axis=0))
+    assert eq(da.nanargmax(a, axis=0, max_leaves=2), np.nanargmax(x, axis=0))
+    assert eq(da.nanargmin(a, axis=0, max_leaves=2), np.nanargmin(x, axis=0))
+    assert eq(da.argmax(a, axis=1, max_leaves=2), np.argmax(x, axis=1))
+    assert eq(da.argmin(a, axis=1, max_leaves=2), np.argmin(x, axis=1))
+    assert eq(da.nanargmax(a, axis=1, max_leaves=2), np.nanargmax(x, axis=1))
+    assert eq(da.nanargmin(a, axis=1, max_leaves=2), np.nanargmin(x, axis=1))
+
 
 def test_reductions_2D_nans():
     # chunks are a mix of some/all/no NaNs
@@ -223,6 +229,7 @@ def test_reductions_with_negative_axes():
     a = da.from_array(x, chunks=2)
 
     assert eq(a.argmin(axis=-1), x.argmin(axis=-1))
+    assert eq(a.argmin(axis=-1, max_leaves=2), x.argmin(axis=-1))
 
     assert eq(a.sum(axis=-1), x.sum(axis=-1))
     assert eq(a.sum(axis=(0, -1)), x.sum(axis=(0, -1)))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -28,7 +28,7 @@ def same_keys(a, b):
     return sorted(a.dask, key=key) == sorted(b.dask, key=key)
 
 
-def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, max_leaves=True):
+def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, split_threshold=True):
     assert eq(da_func(darr), np_func(narr))
     assert eq(da_func(darr, keepdims=True), np_func(narr, keepdims=True))
     assert same_keys(da_func(darr), da_func(darr))
@@ -37,13 +37,13 @@ def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, max_leaves=T
         assert eq(da_func(darr, dtype='f8'), np_func(narr, dtype='f8'))
         assert eq(da_func(darr, dtype='i8'), np_func(narr, dtype='i8'))
         assert same_keys(da_func(darr, dtype='i8'), da_func(darr, dtype='i8'))
-    if max_leaves:
-        a1 = da_func(darr, max_leaves=2)
-        a2 = da_func(darr, max_leaves={0: 2})
+    if split_threshold:
+        a1 = da_func(darr, split_threshold=2)
+        a2 = da_func(darr, split_threshold={0: 2})
         assert same_keys(a1, a2)
         assert eq(a1, np_func(narr))
         assert eq(a2, np_func(narr))
-        assert eq(da_func(darr, keepdims=True, max_leaves=2),
+        assert eq(da_func(darr, keepdims=True, split_threshold=2),
                   np_func(narr, keepdims=True))
 
 
@@ -76,14 +76,14 @@ def test_reductions_1D(dtype):
     assert eq(da.nanargmax(a, axis=0), np.nanargmax(x, axis=0))
     assert eq(da.nanargmin(a, axis=0), np.nanargmin(x, axis=0))
 
-    assert eq(da.argmax(a, axis=0, max_leaves=2), np.argmax(x, axis=0))
-    assert eq(da.argmin(a, axis=0, max_leaves=2), np.argmin(x, axis=0))
-    assert eq(da.nanargmax(a, axis=0, max_leaves=2), np.nanargmax(x, axis=0))
-    assert eq(da.nanargmin(a, axis=0, max_leaves=2), np.nanargmin(x, axis=0))
+    assert eq(da.argmax(a, axis=0, split_threshold=2), np.argmax(x, axis=0))
+    assert eq(da.argmin(a, axis=0, split_threshold=2), np.argmin(x, axis=0))
+    assert eq(da.nanargmax(a, axis=0, split_threshold=2), np.nanargmax(x, axis=0))
+    assert eq(da.nanargmin(a, axis=0, split_threshold=2), np.nanargmin(x, axis=0))
 
 
 def reduction_2d_test(da_func, darr, np_func, narr, use_dtype=True,
-                      max_leaves=True):
+                      split_threshold=True):
     assert eq(da_func(darr), np_func(narr))
     assert eq(da_func(darr, keepdims=True), np_func(narr, keepdims=True))
     assert eq(da_func(darr, axis=0), np_func(narr, axis=0))
@@ -99,19 +99,19 @@ def reduction_2d_test(da_func, darr, np_func, narr, use_dtype=True,
         assert eq(da_func(darr, dtype='f8'), np_func(narr, dtype='f8'))
         assert eq(da_func(darr, dtype='i8'), np_func(narr, dtype='i8'))
 
-    if max_leaves:
-        a1 = da_func(darr, max_leaves=4)
-        a2 = da_func(darr, max_leaves={0: 2, 1: 2})
+    if split_threshold:
+        a1 = da_func(darr, split_threshold=4)
+        a2 = da_func(darr, split_threshold={0: 2, 1: 2})
         assert same_keys(a1, a2)
         assert eq(a1, np_func(narr))
         assert eq(a2, np_func(narr))
-        assert eq(da_func(darr, keepdims=True, max_leaves=4),
+        assert eq(da_func(darr, keepdims=True, split_threshold=4),
                   np_func(narr, keepdims=True))
-        assert eq(da_func(darr, axis=0, max_leaves=2), np_func(narr, axis=0))
-        assert eq(da_func(darr, axis=0, keepdims=True, max_leaves=2),
+        assert eq(da_func(darr, axis=0, split_threshold=2), np_func(narr, axis=0))
+        assert eq(da_func(darr, axis=0, keepdims=True, split_threshold=2),
                   np_func(narr, axis=0, keepdims=True))
-        assert eq(da_func(darr, axis=1, max_leaves=2), np_func(narr, axis=1))
-        assert eq(da_func(darr, axis=1, keepdims=True, max_leaves=2),
+        assert eq(da_func(darr, axis=1, split_threshold=2), np_func(narr, axis=1))
+        assert eq(da_func(darr, axis=1, keepdims=True, split_threshold=2),
                   np_func(narr, axis=1, keepdims=True))
 
 
@@ -151,14 +151,14 @@ def test_reductions_2D(dtype):
     assert eq(da.nanargmax(a, axis=1), np.nanargmax(x, axis=1))
     assert eq(da.nanargmin(a, axis=1), np.nanargmin(x, axis=1))
 
-    assert eq(da.argmax(a, axis=0, max_leaves=2), np.argmax(x, axis=0))
-    assert eq(da.argmin(a, axis=0, max_leaves=2), np.argmin(x, axis=0))
-    assert eq(da.nanargmax(a, axis=0, max_leaves=2), np.nanargmax(x, axis=0))
-    assert eq(da.nanargmin(a, axis=0, max_leaves=2), np.nanargmin(x, axis=0))
-    assert eq(da.argmax(a, axis=1, max_leaves=2), np.argmax(x, axis=1))
-    assert eq(da.argmin(a, axis=1, max_leaves=2), np.argmin(x, axis=1))
-    assert eq(da.nanargmax(a, axis=1, max_leaves=2), np.nanargmax(x, axis=1))
-    assert eq(da.nanargmin(a, axis=1, max_leaves=2), np.nanargmin(x, axis=1))
+    assert eq(da.argmax(a, axis=0, split_threshold=2), np.argmax(x, axis=0))
+    assert eq(da.argmin(a, axis=0, split_threshold=2), np.argmin(x, axis=0))
+    assert eq(da.nanargmax(a, axis=0, split_threshold=2), np.nanargmax(x, axis=0))
+    assert eq(da.nanargmin(a, axis=0, split_threshold=2), np.nanargmin(x, axis=0))
+    assert eq(da.argmax(a, axis=1, split_threshold=2), np.argmax(x, axis=1))
+    assert eq(da.argmin(a, axis=1, split_threshold=2), np.argmin(x, axis=1))
+    assert eq(da.nanargmax(a, axis=1, split_threshold=2), np.nanargmax(x, axis=1))
+    assert eq(da.nanargmin(a, axis=1, split_threshold=2), np.nanargmin(x, axis=1))
 
 
 def test_reductions_2D_nans():
@@ -219,9 +219,9 @@ def test_moment():
     assert eq(a.moment(4, axis=(1, 0)), moment(x, 4, axis=(1, 0)))
 
     # Tree reduction
-    assert eq(a.moment(order=4, max_leaves=4), moment(x, 4))
-    assert eq(a.moment(order=4, axis=0, max_leaves=4), moment(x, 4, axis=0))
-    assert eq(a.moment(order=4, axis=1, max_leaves=4), moment(x, 4, axis=1))
+    assert eq(a.moment(order=4, split_threshold=4), moment(x, 4))
+    assert eq(a.moment(order=4, axis=0, split_threshold=4), moment(x, 4, axis=0))
+    assert eq(a.moment(order=4, axis=1, split_threshold=4), moment(x, 4, axis=1))
 
 
 def test_reductions_with_negative_axes():
@@ -229,7 +229,7 @@ def test_reductions_with_negative_axes():
     a = da.from_array(x, chunks=2)
 
     assert eq(a.argmin(axis=-1), x.argmin(axis=-1))
-    assert eq(a.argmin(axis=-1, max_leaves=2), x.argmin(axis=-1))
+    assert eq(a.argmin(axis=-1, split_threshold=2), x.argmin(axis=-1))
 
     assert eq(a.sum(axis=-1), x.sum(axis=-1))
     assert eq(a.sum(axis=(0, -1)), x.sum(axis=(0, -1)))
@@ -272,14 +272,14 @@ def test_reduction_on_scalar():
 def test_tree_reduce_depth():
     x = da.from_array(np.arange(242).reshape((11, 22)), chunks=(3, 4))
     # Check that tree depth is 2
-    o = x.sum(axis=0, max_leaves=3)
+    o = x.sum(axis=0, split_threshold=3)
     d1 = o.dask[(o.name, 0)]
     assert len(d1[1]) == 2
     d2 = o.dask[d1[1][0]]
     assert len(d2[1]) == 3
     assert all(i[0].startswith('atop') for i in d2[1])
     # Check that tree depth is 3
-    o = x.sum(axis=1, max_leaves=2)
+    o = x.sum(axis=1, split_threshold=2)
     d1 = o.dask[(o.name, 0)]
     assert len(d1[1]) == 2
     d2 = o.dask[d1[1][0]]
@@ -291,6 +291,6 @@ def test_tree_reduce_depth():
 
 def test_partial_reduce_names():
     x = da.from_array(np.arange(242).reshape((11, 22)), chunks=(3, 4))
-    assert x.sum(axis=0).name == x.sum(axis=0, max_leaves=3).name
-    assert x.sum(axis=1).name == x.sum(axis=1, max_leaves=3).name
-    assert x.sum().name == x.sum(max_leaves=3).name
+    assert x.sum(axis=0).name == x.sum(axis=0, split_threshold=3).name
+    assert x.sum(axis=1).name == x.sum(axis=1, split_threshold=3).name
+    assert x.sum().name == x.sum(split_threshold=3).name

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -36,7 +36,7 @@ def test_arg_reduction():
     assert eq(result, np.array([101, 11, 103]))
 
 
-def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, max_leaves=False):
+def reduction_1d_test(da_func, darr, np_func, narr, use_dtype=True, max_leaves=True):
     assert eq(da_func(darr), np_func(narr))
     assert eq(da_func(darr, keepdims=True), np_func(narr, keepdims=True))
     assert same_keys(da_func(darr), da_func(darr))
@@ -60,24 +60,24 @@ def test_reductions_1D(dtype):
     x = np.arange(5).astype(dtype)
     a = da.from_array(x, chunks=(2,))
 
-    reduction_1d_test(da.sum, a, np.sum, x, max_leaves=True)
-    reduction_1d_test(da.prod, a, np.prod, x, max_leaves=True)
-    reduction_1d_test(da.mean, a, np.mean, x, max_leaves=True)
+    reduction_1d_test(da.sum, a, np.sum, x)
+    reduction_1d_test(da.prod, a, np.prod, x)
+    reduction_1d_test(da.mean, a, np.mean, x)
     reduction_1d_test(da.var, a, np.var, x)
     reduction_1d_test(da.std, a, np.std, x)
-    reduction_1d_test(da.min, a, np.min, x, False, max_leaves=True)
-    reduction_1d_test(da.max, a, np.max, x, False, max_leaves=True)
-    reduction_1d_test(da.any, a, np.any, x, False, max_leaves=True)
-    reduction_1d_test(da.all, a, np.all, x, False, max_leaves=True)
+    reduction_1d_test(da.min, a, np.min, x, False)
+    reduction_1d_test(da.max, a, np.max, x, False)
+    reduction_1d_test(da.any, a, np.any, x, False)
+    reduction_1d_test(da.all, a, np.all, x, False)
 
-    reduction_1d_test(da.nansum, a, np.nansum, x, max_leaves=True)
+    reduction_1d_test(da.nansum, a, np.nansum, x)
     with ignoring(AttributeError):
-        reduction_1d_test(da.nanprod, a, np.nanprod, x, max_leaves=True)
-    reduction_1d_test(da.nanmean, a, np.mean, x, max_leaves=True)
+        reduction_1d_test(da.nanprod, a, np.nanprod, x)
+    reduction_1d_test(da.nanmean, a, np.mean, x)
     reduction_1d_test(da.nanvar, a, np.var, x)
     reduction_1d_test(da.nanstd, a, np.std, x)
-    reduction_1d_test(da.nanmin, a, np.nanmin, x, False, max_leaves=True)
-    reduction_1d_test(da.nanmax, a, np.nanmax, x, False, max_leaves=True)
+    reduction_1d_test(da.nanmin, a, np.nanmin, x, False)
+    reduction_1d_test(da.nanmax, a, np.nanmax, x, False)
 
     assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
     assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
@@ -86,7 +86,7 @@ def test_reductions_1D(dtype):
 
 
 def reduction_2d_test(da_func, darr, np_func, narr, use_dtype=True,
-                      max_leaves=False):
+                      max_leaves=True):
     assert eq(da_func(darr), np_func(narr))
     assert eq(da_func(darr, keepdims=True), np_func(narr, keepdims=True))
     assert eq(da_func(darr, axis=0), np_func(narr, axis=0))
@@ -126,24 +126,24 @@ def test_reductions_2D(dtype):
     b = a.sum(keepdims=True)
     assert b._keys() == [[(b.name, 0, 0)]]
 
-    reduction_2d_test(da.sum, a, np.sum, x, max_leaves=True)
-    reduction_2d_test(da.prod, a, np.prod, x, max_leaves=True)
-    reduction_2d_test(da.mean, a, np.mean, x, max_leaves=True)
+    reduction_2d_test(da.sum, a, np.sum, x)
+    reduction_2d_test(da.prod, a, np.prod, x)
+    reduction_2d_test(da.mean, a, np.mean, x)
     reduction_2d_test(da.var, a, np.var, x, False)  # Difference in dtype algo
     reduction_2d_test(da.std, a, np.std, x, False)  # Difference in dtype algo
-    reduction_2d_test(da.min, a, np.min, x, False, max_leaves=True)
-    reduction_2d_test(da.max, a, np.max, x, False, max_leaves=True)
-    reduction_2d_test(da.any, a, np.any, x, False, max_leaves=True)
-    reduction_2d_test(da.all, a, np.all, x, False, max_leaves=True)
+    reduction_2d_test(da.min, a, np.min, x, False)
+    reduction_2d_test(da.max, a, np.max, x, False)
+    reduction_2d_test(da.any, a, np.any, x, False)
+    reduction_2d_test(da.all, a, np.all, x, False)
 
-    reduction_2d_test(da.nansum, a, np.nansum, x, max_leaves=True)
+    reduction_2d_test(da.nansum, a, np.nansum, x)
     with ignoring(AttributeError):
-        reduction_2d_test(da.nanprod, a, np.nanprod, x, max_leaves=True)
-    reduction_2d_test(da.nanmean, a, np.mean, x, max_leaves=True)
+        reduction_2d_test(da.nanprod, a, np.nanprod, x)
+    reduction_2d_test(da.nanmean, a, np.mean, x)
     reduction_2d_test(da.nanvar, a, np.nanvar, x, False)  # Difference in dtype algo
     reduction_2d_test(da.nanstd, a, np.nanstd, x, False)  # Difference in dtype algo
-    reduction_2d_test(da.nanmin, a, np.nanmin, x, False, max_leaves=True)
-    reduction_2d_test(da.nanmax, a, np.nanmax, x, False, max_leaves=True)
+    reduction_2d_test(da.nanmin, a, np.nanmin, x, False)
+    reduction_2d_test(da.nanmax, a, np.nanmax, x, False)
 
     assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
     assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
@@ -163,24 +163,24 @@ def test_reductions_2D_nans():
     x[3, 3] = 6
     a = da.from_array(x, chunks=(2, 2))
 
-    reduction_2d_test(da.sum, a, np.sum, x, False)
-    reduction_2d_test(da.prod, a, np.prod, x, False)
-    reduction_2d_test(da.mean, a, np.mean, x, False)
-    reduction_2d_test(da.var, a, np.var, x, False)
-    reduction_2d_test(da.std, a, np.std, x, False)
-    reduction_2d_test(da.min, a, np.min, x, False)
-    reduction_2d_test(da.max, a, np.max, x, False)
-    reduction_2d_test(da.any, a, np.any, x, False)
-    reduction_2d_test(da.all, a, np.all, x, False)
+    reduction_2d_test(da.sum, a, np.sum, x, False, False)
+    reduction_2d_test(da.prod, a, np.prod, x, False, False)
+    reduction_2d_test(da.mean, a, np.mean, x, False, False)
+    reduction_2d_test(da.var, a, np.var, x, False, False)
+    reduction_2d_test(da.std, a, np.std, x, False, False)
+    reduction_2d_test(da.min, a, np.min, x, False, False)
+    reduction_2d_test(da.max, a, np.max, x, False, False)
+    reduction_2d_test(da.any, a, np.any, x, False, False)
+    reduction_2d_test(da.all, a, np.all, x, False, False)
 
-    reduction_2d_test(da.nansum, a, np.nansum, x, False)
+    reduction_2d_test(da.nansum, a, np.nansum, x, False, False)
     with ignoring(AttributeError):
-        reduction_2d_test(da.nanprod, a, np.nanprod, x, False)
-    reduction_2d_test(da.nanmean, a, np.nanmean, x, False)
-    reduction_2d_test(da.nanvar, a, np.nanvar, x, False)
-    reduction_2d_test(da.nanstd, a, np.nanstd, x, False)
-    reduction_2d_test(da.nanmin, a, np.nanmin, x, False)
-    reduction_2d_test(da.nanmax, a, np.nanmax, x, False)
+        reduction_2d_test(da.nanprod, a, np.nanprod, x, False, False)
+    reduction_2d_test(da.nanmean, a, np.nanmean, x, False, False)
+    reduction_2d_test(da.nanvar, a, np.nanvar, x, False, False)
+    reduction_2d_test(da.nanstd, a, np.nanstd, x, False, False)
+    reduction_2d_test(da.nanmin, a, np.nanmin, x, False, False)
+    reduction_2d_test(da.nanmax, a, np.nanmax, x, False, False)
 
     # TODO: fix these tests, which fail with this error from NumPy:
     # ValueError("All-NaN slice encountered"), because some of the chunks
@@ -211,6 +211,11 @@ def test_moment():
     a = da.from_array(x, chunks=(4, 4))
     assert eq(a.moment(4, axis=1), moment(x, 4, axis=1))
     assert eq(a.moment(4, axis=(1, 0)), moment(x, 4, axis=(1, 0)))
+
+    # Tree reduction
+    assert eq(a.moment(order=4, max_leaves=4), moment(x, 4))
+    assert eq(a.moment(order=4, axis=0, max_leaves=4), moment(x, 4, axis=0))
+    assert eq(a.moment(order=4, axis=1, max_leaves=4), moment(x, 4, axis=1))
 
 
 def test_reductions_with_negative_axes():

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -5,6 +5,7 @@ pytest.importorskip('numpy')
 
 import dask.array as da
 from dask.core import get_deps
+from dask.context import set_options
 from dask.utils import ignoring
 import numpy as np
 
@@ -309,3 +310,10 @@ def test_tree_reduce_depth():
     assert_max_deps(x.sum(axis=(0, 1), split_threshold=40), 4 * 6)
     assert_max_deps(x.sum(axis=(0, 2), split_threshold=40), 4 * 6)
     assert_max_deps(x.sum(axis=(1, 2), split_threshold=40), 6 * 6)
+
+
+def test_tree_reduce_set_options():
+    x = da.from_array(np.arange(242).reshape((11, 22)), chunks=(3, 4))
+    with set_options(split_threshold={0: 2, 1: 3}):
+        assert_max_deps(x.sum(), 2 * 3)
+        assert_max_deps(x.sum(axis=0), 2)


### PR DESCRIPTION
This enables support for tree reductions, which should improve efficiency of using `dask.array` across multiple processes/machines, or when arrays are composed of a large number of chunks.

The idea is to set a maximum number of chunks to be gathered and combined (either overall, or by axis) when performing reductions - breaking the reduce step of map-reduce into a tree of smaller reductions.

At an api level, reductions expose a `max_leaves` kwarg, which defaults to the current behavior. It accepts either a `dict` of `{axis: max_chunks}`, or an integer, which is used to compute `max_chunks` for each dimension such that the total number of chunks gathered in each reduction is approximately `max_leaves`. For example, `axis=0, max_leaves=16 -> max_leaves={0: 16}`, `axis=(0, 1), max_leaves=16 -> max_leaves={0: 4, 1: 4}`.

Example:

```python
import dask.array as da
import numpy as np

x = np.arange(1, 122).reshape((11, 11)).astype('f4')
a = da.from_array(x, chunks=(4, 4))
o = a.sum(axis=0, max_leaves=4)
```
![mydask](https://cloud.githubusercontent.com/assets/2783717/11287254/d7860d8a-8edf-11e5-86a1-dbe05f9314a5.png)

What would normally be a single step reduction has been broken into a tree of depth 2.

Todo:
- [x] Add support for `moment` (and thus `std`, `var`, etc...)
- [x] Add support for `arg*` reductions
- [x] More tests
