### PR TITLE
Significant performance improvement in bag.core._chunk_read_file

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -11,7 +11,7 @@ import math
 from dask.bag.core import (Bag, lazify, lazify_task, fuse, map, collect,
         reduceby, bz2_stream, stream_decompress, reify, partition,
         _parse_s3_URI, inline_singleton_lists, optimize, decode_sequence,
-        system_encoding)
+        system_encoding, _readlines, pluck)
 from dask.utils import filetexts, tmpfile, raises
 from dask.async import get_sync
 import dask
@@ -326,16 +326,16 @@ def test_from_filenames_gzip():
     b = db.from_filenames(['foo.json.gz', 'bar.json.gz'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('foo.json.gz'), 'rb'))),
-                 (list, (decode_sequence, system_encoding, (gzip.open, os.path.abspath('bar.json.gz'), 'rb')))]))
+            set([(list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (gzip.open, os.path.abspath('foo.json.gz'), 'rb'), system_encoding, '\n')))),
+                 (list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (gzip.open, os.path.abspath('bar.json.gz'), 'rb'), system_encoding, '\n'))))]))
 
 
 def test_from_filenames_bz2():
     b = db.from_filenames(['foo.json.bz2', 'bar.json.bz2'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('foo.json.bz2'), 'rb'))),
-                 (list, (decode_sequence, system_encoding, (bz2.BZ2File, os.path.abspath('bar.json.bz2'), 'rb')))]))
+            set([(list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (bz2.BZ2File, os.path.abspath('foo.json.bz2'), 'rb'), system_encoding, '\n')))),
+                 (list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (bz2.BZ2File, os.path.abspath('bar.json.bz2'), 'rb'), system_encoding, '\n'))))]))
 
 
 def test_from_filenames_large():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -11,11 +11,12 @@ import math
 from dask.bag.core import (Bag, lazify, lazify_task, fuse, map, collect,
         reduceby, bz2_stream, stream_decompress, reify, partition,
         _parse_s3_URI, inline_singleton_lists, optimize, decode_sequence,
-        system_encoding, _readlines, pluck)
+        system_encoding)
 from dask.utils import filetexts, tmpfile, raises
 from dask.async import get_sync
 import dask
 import dask.bag as db
+import io
 import shutil
 import os
 import gzip
@@ -326,16 +327,32 @@ def test_from_filenames_gzip():
     b = db.from_filenames(['foo.json.gz', 'bar.json.gz'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (gzip.open, os.path.abspath('foo.json.gz'), 'rb'), system_encoding, '\n')))),
-                 (list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (gzip.open, os.path.abspath('bar.json.gz'), 'rb'), system_encoding, '\n'))))]))
+            set([(list,
+                  (io.TextIOWrapper,
+                   (io.BufferedReader,
+                    (gzip.open, os.path.abspath('foo.json.gz'), 'rb')),
+                   system_encoding, None, '\n')),
+                 (list,
+                  (io.TextIOWrapper,
+                   (io.BufferedReader,
+                    (gzip.open, os.path.abspath('bar.json.gz'), 'rb')),
+                   system_encoding, None, '\n'))]))
 
 
 def test_from_filenames_bz2():
     b = db.from_filenames(['foo.json.bz2', 'bar.json.bz2'])
 
     assert (set(b.dask.values()) ==
-            set([(list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (bz2.BZ2File, os.path.abspath('foo.json.bz2'), 'rb'), system_encoding, '\n')))),
-                 (list, (decode_sequence, system_encoding, (pluck, 0, (_readlines, (bz2.BZ2File, os.path.abspath('bar.json.bz2'), 'rb'), system_encoding, '\n'))))]))
+            set([(list,
+                  (io.TextIOWrapper,
+                   (io.BufferedReader,
+                    (bz2.BZ2File, os.path.abspath('foo.json.bz2'), 'rb')),
+                   system_encoding, None, '\n')),
+                 (list,
+                  (io.TextIOWrapper,
+                   (io.BufferedReader,
+                    (bz2.BZ2File, os.path.abspath('bar.json.bz2'), 'rb')),
+                   system_encoding, None, '\n'))]))
 
 
 def test_from_filenames_large():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -10,8 +10,7 @@ from toolz import (merge, join, pipe, filter, identity, merge_with, take,
 import math
 from dask.bag.core import (Bag, lazify, lazify_task, fuse, map, collect,
         reduceby, bz2_stream, stream_decompress, reify, partition,
-        _parse_s3_URI, inline_singleton_lists, optimize, decode_sequence,
-        system_encoding)
+        _parse_s3_URI, inline_singleton_lists, optimize, system_encoding)
 from dask.utils import filetexts, tmpfile, raises
 from dask.async import get_sync
 import dask

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -52,41 +52,119 @@ else:
     def _getargspec(func):
         return inspect.getargspec(func)
 
-    if sys.version_info[1] <= 6:
-        class BZ2File(bz2.BZ2File, BufferedIOBase):
+    if sys.version_info[1] <= 7:
+        class BZ2File(BufferedIOBase):
             def __init__(self, *args, **kwargs):
-                super(BZ2File, self).__init__(*args, **kwargs)
+                self.__obj = bz2.BZ2File(*args, **kwargs)
+
+            def close(self):
+                return self.__obj.close()
+
+            @property
+            def closed(self):
+                return self.__obj.closed
+
+            def flush(self):
+                pass
+
+            def isatty(self):
+                return self.__obj.isatty()
+
+            def read(self, *args, **kwargs):
+                return self.__obj.read(*args, **kwargs)
+
+            def read1(self, *args, **kwargs):
+                return self.__obj.read(*args, **kwargs)
 
             def readable(self):
-                return 'r' in self.mode
+                return 'r' in self.__obj.mode
 
-            def writable(self):
-                return 'w' in self.mode
+            def readline(self, *args, **kwargs):
+                return self.__obj.readline(*args, **kwargs)
+
+            def readlines(self, *args, **kwargs):
+                return self.__obj.readlines(*args, **kwargs)
+
+            def seek(self, *args, **kwargs):
+                self.__obj.seek(*args, **kwargs)
+                return self.tell()
 
             def seekable(self):
                 return self.readable()
 
-            def read1(self, size=-1):
-                return self.read(size)
+            def tell(self):
+                return self.__obj.tell()
 
-        class GzipFile(gzip.GzipFile, BufferedIOBase):
-            def __init__(self, *args, **kwargs):
-                super(GzipFile, self).__init__(*args, **kwargs)
-
-            def readable(self):
-                return self.mode == gzip.READ
+            def truncate(self, *args, **kwargs):
+                return self.__obj.truncate(*args, **kwargs)
 
             def writable(self):
-                return self.mode == gzip.WRITE
+                return 'w' in self.__obj.mode
 
-            def seekable(self):
-                # TODO: Can we really hard-code True here?
-                return True
+            def write(self, *args, **kwargs):
+                return self.__obj.write(*args, **kwargs)
 
-            def read1(self, size=-1):
-                return self.read(size)
+            def writelines(self, *args, **kwargs):
+                return self.__obj.writelines(*args, **kwargs)
     else:
         BZ2File = bz2.BZ2File
+
+    if sys.version_info[1] <= 6:
+        class GzipFile(BufferedIOBase):
+            def __init__(self, *args, **kwargs):
+                self.__obj = gzip.GzipFile(*args, **kwargs)
+
+            def close(self):
+                return self.__obj.close()
+
+            @property
+            def closed(self):
+                return self.__obj.fileobj is None
+
+            def flush(self, *args, **kwargs):
+                return self.__obj.flush(*args, **kwargs)
+
+            def isatty(self):
+                return self.__obj.isatty()
+
+            def read(self, *args, **kwargs):
+                return self.__obj.read(*args, **kwargs)
+
+            def read1(self, *args, **kwargs):
+                return self.__obj.read(*args, **kwargs)
+
+            def readable(self):
+                return self.__obj.mode == gzip.READ
+
+            def readline(self, *args, **kwargs):
+                return self.__obj.readline(*args, **kwargs)
+
+            def readlines(self, *args, **kwargs):
+                return self.__obj.readlines(*args, **kwargs)
+
+            def seek(self, *args, **kwargs):
+                self.__obj.seek(*args, **kwargs)
+                return self.tell()
+
+            def seekable(self):
+                # See https://hg.python.org/cpython/file/2.7/Lib/gzip.py#l421
+                return True
+
+            def tell(self):
+                return self.__obj.tell()
+
+            def truncate(self, *args, **kwargs):
+                return self.__obj.truncate(*args, **kwargs)
+
+            def writable(self):
+                return self.__obj.mode == gzip.WRITE
+
+            def write(self, *args, **kwargs):
+                return self.__obj.write(*args, **kwargs)
+
+            def writelines(self, *args, **kwargs):
+                return self.__obj.writelines(*args, **kwargs)
+    else:
         GzipFile = gzip.GzipFile
 
 

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import codecs
 from fnmatch import fnmatch
-from functools import wraps, partial
+from functools import wraps
 from glob import glob
 from math import ceil
 from operator import getitem
@@ -14,8 +15,8 @@ import pandas as pd
 import numpy as np
 from toolz import merge, assoc, dissoc
 
-from ..compatibility import BytesIO, unicode, range, apply
-from ..utils import textblock, file_size, get_bom
+from ..compatibility import StringIO, unicode, range, apply
+from ..utils import textblock, file_size, get_bom, system_encoding
 from ..base import tokenize
 from .. import array as da
 from ..async import get_sync
@@ -30,9 +31,23 @@ csv_defaults = {'compression': None}
 
 
 def _read_csv(fn, i, chunkbytes, compression, kwargs, bom):
-    block = textblock(fn, i*chunkbytes, (i+1) * chunkbytes, compression,
-                      encoding=kwargs.get('encoding'))
-    block = BytesIO(bom + block)
+    kwargs = kwargs.copy()
+    linesep = kwargs.get('lineterminator', os.linesep)
+    encoding = kwargs.pop('encoding', system_encoding)
+
+    start = i * chunkbytes
+    end = start + chunkbytes
+
+    if encoding == 'utf-16':
+        bom_encoding = {codecs.BOM_UTF16_BE: 'utf-16-be',
+                        codecs.BOM_UTF16_LE: 'utf-16-le'}
+        if not bom:
+            bom = codecs.BOM_UTF16
+        if i > 0:
+            encoding = bom_encoding[bom]
+
+    block = StringIO(u''.join(textblock(fn, start, end, compression, encoding,
+                                        linesep)))
     try:
         return pd.read_csv(block, **kwargs)
     except ValueError as e:
@@ -68,6 +83,8 @@ def _read_csv(fn, i, chunkbytes, compression, kwargs, bom):
         #       as apporpriate
 
         raise ValueError(msg)
+    finally:
+        block.close()
 
 
 def clean_kwargs(kwargs):
@@ -192,7 +209,7 @@ def read_csv(fn, **kwargs):
 
     token = tokenize(os.path.getmtime(fn), kwargs)
     name = 'read-csv-%s-%s' % (fn, token)
-    bom = get_bom(fn)
+    bom = get_bom(fn, kwargs.get('compression', None))
 
     # Chunk sizes and numbers
     total_bytes = file_size(fn, kwargs['compression'])

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -16,7 +16,7 @@ import dask.array as da
 import dask.dataframe as dd
 from dask.dataframe.io import (read_csv, file_size,  dataframe_from_ctable,
         from_array, from_bcolz, from_dask_array)
-from dask.compatibility import StringIO
+from dask.compatibility import StringIO, BZ2File, GzipFile
 
 from dask.utils import filetext, tmpfile, ignoring
 from dask.async import get_sync
@@ -51,7 +51,7 @@ def test_read_csv():
 
 
 def test_read_gzip_csv():
-    with filetext(text.encode(), open=gzip.open) as fn:
+    with filetext(text.encode(), open=GzipFile) as fn:
         f = dd.read_csv(fn, chunkbytes=30, compression='gzip')
         assert list(f.columns) == ['name', 'amount']
         assert f.npartitions > 1
@@ -64,7 +64,7 @@ def test_file_size():
     counts = (len(text), len(text) + text.count('\n'))
     with filetext(text) as fn:
         assert file_size(fn) in counts
-    with filetext(text.encode(), open=gzip.open) as fn:
+    with filetext(text.encode(), open=GzipFile) as fn:
         assert file_size(fn, 'gzip') in counts
 
 

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -4,21 +4,18 @@ from itertools import product
 import numpy as np
 
 from dask.utils import (textblock, filetext, takes_multiple_arguments,
-                        Dispatch, tmpfile, next_linesep, different_seeds)
+                        Dispatch, tmpfile, different_seeds)
 
 
 def test_textblock():
     text = b'123 456 789 abc def ghi'.replace(b' ', os.linesep.encode())
     with filetext(text, mode='wb') as fn:
-        with open(fn, 'rb') as f:
-            text = textblock(f, 1, 11)
-            assert text == ('456 789 '.replace(' ', os.linesep)).encode()
-            assert set(map(len, text.split())) == set([3])
+        text = ''.join(textblock(fn, 1, 11, None))
+        assert text == ('456 789 '.replace(' ', os.linesep)).encode()
+        assert set(map(len, text.split())) == set([3])
 
-            assert textblock(f, 1, 10) == textblock(fn, 1, 10)
-
-            assert textblock(f, 0, 3) == ('123' + os.linesep).encode()
-            assert textblock(f, 3, 3) == b''
+        assert ''.join(textblock(fn, 0, 3, None)) == ('123' + os.linesep).encode()
+        assert ''.join(textblock(fn, 3, 3, None)) == b''
 
 
 def test_takes_multiple_arguments():
@@ -57,38 +54,6 @@ def test_dispatch():
     assert foo((1, 2.0, b)) == (2, 1.0, b)
 
 
-def test_nextlinesep():
-    lineseps = ('\r', '\n', '\r\n')
-    encodings = ('utf-16-le', 'utf-8')
-    for sep, encoding in product(lineseps, encodings):
-        euro = u'\u20ac'
-        yen = u'\u00a5'
-
-        bin_euro = u'\u20ac'.encode(encoding)
-        bin_yen = u'\u00a5'.encode(encoding)
-        bin_sep = sep.encode(encoding)
-
-        data = (euro * 10) + sep + (yen * 10) + sep + (euro * 10)
-        bin_data = data.encode(encoding)
-
-        with tmpfile() as fn:
-            with open(fn, 'w+b') as f:
-                f.write(bin_data)
-                f.seek(0)
-
-                start, stop = next_linesep(f, 5, encoding, sep)
-                assert start == len(bin_euro) * 10
-                assert stop == len(bin_euro) * 10 + len(sep.encode(encoding))
-
-                seek = len(bin_euro) * 10 + len(bin_sep) + len(bin_yen)
-                start, stop = next_linesep(f, seek, encoding, sep)
-
-                exp_start = len(bin_euro) * 10 + len(bin_sep) + len(bin_yen) * 10
-                exp_stop = exp_start + len(bin_sep)
-                assert start == exp_start
-                assert stop == exp_stop
-
-
 def test_gh606():
     encoding = 'utf-16-le'
     euro = u'\u20ac'
@@ -103,17 +68,16 @@ def test_gh606():
     bin_data = data.encode(encoding)
 
     with tmpfile() as fn:
-        with open(fn, 'w+b') as f:
+        with open(fn, 'wb') as f:
             f.write(bin_data)
-            f.seek(0)
 
-            stop = len(bin_euro) * 10 + len(bin_linesep)
-            res = textblock(f, 1, stop, encoding=encoding)
-            assert res == ((yen * 10) + linesep).encode(encoding)
+        stop = len(bin_euro) * 10 + len(bin_linesep)
+        res = ''.join(textblock(fn, 1, stop, encoding=encoding)).encode(encoding)
+        assert res == ((yen * 10) + linesep).encode(encoding)
 
-            stop = len(bin_euro) * 10 + len(bin_linesep)
-            res = textblock(f, 0, stop, encoding=encoding)
-            assert res == ((euro * 10) + linesep + (yen * 10) + linesep).encode(encoding)
+        stop = len(bin_euro) * 10 + len(bin_linesep)
+        res = ''.join(textblock(fn, 0, stop, encoding=encoding)).encode(encoding)
+        assert res == ((euro * 10) + linesep + (yen * 10) + linesep).encode(encoding)
 
 
 def test_different_seeds():

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -1,5 +1,4 @@
 import os
-from itertools import product
 
 import numpy as np
 
@@ -14,8 +13,16 @@ def test_textblock():
         assert text == ('456 789 '.replace(' ', os.linesep)).encode()
         assert set(map(len, text.split())) == set([3])
 
-        assert ''.join(textblock(fn, 0, 3, None)).encode() == ('123' + os.linesep).encode()
-        assert ''.join(textblock(fn, 3, 3, None)).encode() == b''
+        assert ''.join(textblock(fn, 0, 4, None)).encode() == ('123' + os.linesep).encode()
+        assert ''.join(textblock(fn, 4, 4, None)).encode() == b''
+
+
+def test_textblock_multibyte_linesep():
+    text = b'12 34 56 78'.replace(b' ', b'\r\n')
+    with filetext(text, mode='wb') as fn:
+        text = [line.encode()
+                for line in textblock(fn, 5, 13, linesep='\r\n', buffersize=2)]
+        assert text == [line.encode() for line in ('56\r\n', '78')]
 
 
 def test_takes_multiple_arguments():
@@ -71,11 +78,11 @@ def test_gh606():
         with open(fn, 'wb') as f:
             f.write(bin_data)
 
-        stop = len(bin_euro) * 10 + len(bin_linesep)
+        stop = len(bin_euro) * 10 + len(bin_linesep) + 1
         res = ''.join(textblock(fn, 1, stop, encoding=encoding)).encode(encoding)
         assert res == ((yen * 10) + linesep).encode(encoding)
 
-        stop = len(bin_euro) * 10 + len(bin_linesep)
+        stop = len(bin_euro) * 10 + len(bin_linesep) + 1
         res = ''.join(textblock(fn, 0, stop, encoding=encoding)).encode(encoding)
         assert res == ((euro * 10) + linesep + (yen * 10) + linesep).encode(encoding)
 

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -10,12 +10,12 @@ from dask.utils import (textblock, filetext, takes_multiple_arguments,
 def test_textblock():
     text = b'123 456 789 abc def ghi'.replace(b' ', os.linesep.encode())
     with filetext(text, mode='wb') as fn:
-        text = ''.join(textblock(fn, 1, 11, None))
+        text = ''.join(textblock(fn, 1, 11, None)).encode()
         assert text == ('456 789 '.replace(' ', os.linesep)).encode()
         assert set(map(len, text.split())) == set([3])
 
-        assert ''.join(textblock(fn, 0, 3, None)) == ('123' + os.linesep).encode()
-        assert ''.join(textblock(fn, 3, 3, None)) == b''
+        assert ''.join(textblock(fn, 0, 3, None)).encode() == ('123' + os.linesep).encode()
+        assert ''.join(textblock(fn, 3, 3, None)).encode() == b''
 
 
 def test_takes_multiple_arguments():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -188,6 +188,20 @@ def get_bin_linesep(encoding, linesep):
 
 def textblock(filename, start, end, compression=None, encoding=system_encoding,
               linesep=os.linesep):
+    """Pull out a block of text from a file given start and stop bytes.
+
+    This gets data starting/ending from the next linesep delimiter.
+
+    Examples
+    --------
+    >> with open('myfile.txt', 'wb') as f:
+    ..     f.write('123\n456\n789\nabc')
+
+    In the example below, 1 and 10 don't line up with endlines.
+
+    >> u''.join(textblock('myfile.txt', 1, 10))
+    '456\n789\n'
+    """
     # Make sure `linesep` is not a byte string because `io.TextIOWrapper` in
     # Python versions other than 2.7 dislike byte strings for the `newline`
     # argument.

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -225,8 +225,7 @@ def textblock(filename, start, end, compression=None, encoding=system_encoding,
 
     chunksize = end - start
 
-    f = open(filename, 'rb', compression)
-    try:
+    with open(filename, 'rb', compression) as f:
         with io.BufferedReader(f) as fb:
             # If `start` does not correspond to the beginning of the file, we
             # need to move the file pointer to `start - len(bin_linesep)`,
@@ -286,8 +285,6 @@ def textblock(filename, start, end, compression=None, encoding=system_encoding,
 
                     yield line
                     start += bin_line_len
-    finally:
-        f.close()
 
 
 def concrete(seq):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -215,7 +215,7 @@ def textblock(filename, start, end, compression=None, encoding=system_encoding,
                 fb.seek(start)
                 while True:
                     buf = f.read(4096)
-                    if buf == '':
+                    if not buf:
                         raise StopIteration
                     try:
                         start += buf.index(bin_linesep)


### PR DESCRIPTION
This PR changes the way a single large text file is processed in parallel using ``from_filenames`` and the ``chunkbytes`` argument. Before, in ``utils.textblock`` ``utils.next_linesep`` determined the exact start and end bytes of each block by actually streaming over the corresponding region in the file and finally the exact region was loaded into memory. This is very inefficient because the region is read twice and loaded into memory while the remaining graph may only require streaming over the bag elements. I noticed the performance problem when processing both a large and even very moderately sized (a couple of MBs) gzipped text file. This PR makes the chunked processing significantly faster.

I have only made changes to the ``bag`` module but saw that ``utils.textblock`` is also used in the ``dataframe`` module. Perhaps my ``bag.core._textblock`` function can be moved to ``utils`` and then ``dataframe`` may be adapted to benefit from the speed-up, too.

I welcome any comments and suggestions.