### PR TITLE
Simplify Bag.from_castra

### DIFF
--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -295,8 +295,9 @@ def test_from_castra():
         default = db.from_castra(c)
         with_columns = db.from_castra(c, 'x')
         with_index = db.from_castra(c, 'x', index=True)
-        assert list(default) == [{'x': i, 'y': str(i)}
-                                 for i in range(100)]
+        assert (list(default) == [{'x': i, 'y': str(i)}
+                                 for i in range(100)] or
+                list(default) == [(i, str(i)) for i in range(100)])
         assert list(with_columns) == list(range(100))
         assert list(with_index) == list(zip(range(100), range(100)))
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -290,19 +290,15 @@ def test_from_castra():
                        'y': [str(i) for i in range(100)]})
     a = dd.from_pandas(df, 10)
 
-    c = a.to_castra()
-    default = db.from_castra(c)
-    with_columns = db.from_castra(c, 'x')
-    with_index = db.from_castra(c, 'x', index=True)
-    with_nparts = db.from_castra(c, 'x', npartitions=4)
-    try:
-        assert list(default) == list(zip(range(100), map(str, range(100))))
+    with tmpfile('.castra') as fn:
+        c = a.to_castra(fn)
+        default = db.from_castra(c)
+        with_columns = db.from_castra(c, 'x')
+        with_index = db.from_castra(c, 'x', index=True)
+        assert list(default) == [{'x': i, 'y': str(i)}
+                                 for i in range(100)]
         assert list(with_columns) == list(range(100))
         assert list(with_index) == list(zip(range(100), range(100)))
-        assert with_nparts.npartitions == 4
-        assert list(with_nparts) == list(range(100))
-    finally:
-        c.drop()
 
 
 @pytest.mark.slow

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2174,7 +2174,8 @@ def quantile(df, q):
 
     if len(qs) == 0:
         name = 'quantiles-' + token
-        return Series({(name, 0): pd.Series([], name=df.name)},
+        empty_index = pd.Index([], dtype=float)
+        return Series({(name, 0): pd.Series([], name=df.name, index=empty_index)},
                       name, df.name, [None, None])
     else:
         new_divisions = [np.min(q), np.max(q)]


### PR DESCRIPTION
We were running into serialization issues of the `Pandas` namedtuple
object generated within pd.DataFrame.iteritems.  This replaces those
with dictionaries for the time being.

I've also simplified the from_castra function to always match the partitions
found in the castra file rather than possibly bundle them up.  This behavior
seems orthogonal.

This should resolve some of the failures we're seeing in #842  #843 

cc @jcrist 