### PR TITLE
Add drop_dims/new_dims kwargs to map_blocks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -409,6 +409,9 @@ def map_blocks(func, *args, **kwargs):
         Dimensions lost by the function
     new_dims: number or iterable (optional)
         New dimensions created by the function
+    **kwargs:
+        Other keyword arguments to pass to function.
+        Values must be constants (not dask.arrays)
 
     You must also specify the chunks and dtype of the resulting array.  If you
     don't then we assume that the resulting array has the same block structure
@@ -479,6 +482,9 @@ def map_blocks(func, *args, **kwargs):
 
     arrs = [a for a in args if isinstance(a, Array)]
     args = [(i, a) for i, a in enumerate(args) if not isinstance(a, Array)]
+
+    if kwargs:
+        func = partial(func, **kwargs)
 
     if args:
         func = partial_by_order(func, args)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -396,9 +396,26 @@ def _concatenate2(arrays, axes=[]):
 def map_blocks(func, *arrs, **kwargs):
     """ Map a function across all blocks of a dask array
 
-    You must also specify the chunks of the resulting array.  If you don't then
-    we assume that the resulting array has the same block structure as the
-    input.
+    Parameters
+    ----------
+    func: callable
+        Function to apply to every block in the array
+    arrs: dask arrays or constants
+    dtype: np.dtype
+        Datatype of resulting array
+    chunks: tuple (optional)
+        chunk shape of resulting blocks if the function does not preserve shape
+    drop_dims: number or iterable (optional)
+        Dimensions lost by the function
+    new_dims: number or iterable (optional)
+        New dimensions created by the function
+
+    You must also specify the chunks and dtype of the resulting array.  If you
+    don't then we assume that the resulting array has the same block structure
+    as the input.
+
+    Examples
+    --------
 
     >>> import dask.array as da
     >>> x = da.arange(6, chunks=3)
@@ -426,10 +443,11 @@ def map_blocks(func, *arrs, **kwargs):
     >>> a = da.arange(18, chunks=(6,))
     >>> b = a.map_blocks(lambda x: x[:3], chunks=(3,))
 
-    If the function changes the dimension of the blocks you must specify that
-    new dimension in the chunks tuples.
+    If the function changes the dimension of the blocks you must specify the
+    created or destroyed dimensions.
 
-    >>> b = a.map_blocks(lambda x: x[None, :, None], chunks=(1, 6, 1))
+    >>> b = a.map_blocks(lambda x: x[None, :, None], chunks=(1, 6, 1),
+    ...                  new_dims=[0, 2])
 
     Your block function can learn where in the array it is if it supports a
     ``block_id`` keyword argument.  This will receive entries like (2, 0, 1),

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -452,6 +452,34 @@ def map_blocks(func, *args, **kwargs):
     >>> b = a.map_blocks(lambda x: x[None, :, None], chunks=(1, 6, 1),
     ...                  new_dims=[0, 2])
 
+
+    Map_blocks aligns blocks by block positions without regard to shape.  In
+    the following example we have two arrays with the same number of blocks but
+    with different shape and chunk sizes.
+
+    >>> x = da.arange(1000, chunks=(100,))
+    >>> y = da.arange(100, chunks=(10,))
+
+    The relevant attribute to match in numblocks
+
+    >>> x.numblocks
+    (10,)
+    >>> y.numblocks
+    (10,)
+
+    If these must match (up to broadcasting rules) then we can map arbitray
+    functions across blocks
+
+    >>> def func(a, b):
+    ...     return np.array([a.max(), b.max()])
+
+    >>> da.map_blocks(func, x, y, chunks=(2,), dtype='i8')
+    dask.array<..., shape=(20,), dtype=int64, chunksize=(2,)>
+
+    >>> _.compute()
+    array([ 99,   9, 199,  19, 299,  29, 399,  39, 499,  49, 599,  59, 699,
+            69, 799,  79, 899,  89, 999,  99])
+
     Your block function can learn where in the array it is if it supports a
     ``block_id`` keyword argument.  This will receive entries like (2, 0, 1),
     the position of the block in the dask array.

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -405,9 +405,9 @@ def map_blocks(func, *args, **kwargs):
         Datatype of resulting array
     chunks: tuple (optional)
         chunk shape of resulting blocks if the function does not preserve shape
-    drop_dims: number or iterable (optional)
+    drop_axis: number or iterable (optional)
         Dimensions lost by the function
-    new_dims: number or iterable (optional)
+    new_axis: number or iterable (optional)
         New dimensions created by the function
     **kwargs:
         Other keyword arguments to pass to function.
@@ -450,7 +450,7 @@ def map_blocks(func, *args, **kwargs):
     created or destroyed dimensions.
 
     >>> b = a.map_blocks(lambda x: x[None, :, None], chunks=(1, 6, 1),
-    ...                  new_dims=[0, 2])
+    ...                  new_axis=[0, 2])
 
 
     Map_blocks aligns blocks by block positions without regard to shape.  In
@@ -501,12 +501,12 @@ def map_blocks(func, *args, **kwargs):
     name = name or 'map-blocks-%s' % tokenize(func, args, **kwargs)
     dtype = kwargs.pop('dtype', None)
     chunks = kwargs.pop('chunks', None)
-    drop_dims = kwargs.pop('drop_dims', [])
-    new_dims = kwargs.pop('new_dims', [])
-    if isinstance(drop_dims, Number):
-        drop_dims = [drop_dims]
-    if isinstance(new_dims, Number):
-        new_dims = [new_dims]
+    drop_axis = kwargs.pop('drop_axis', [])
+    new_axis = kwargs.pop('new_axis', [])
+    if isinstance(drop_axis, Number):
+        drop_axis = [drop_axis]
+    if isinstance(new_axis, Number):
+        new_axis = [new_axis]
 
     arrs = [a for a in args if isinstance(a, Array)]
     args = [(i, a) for i, a in enumerate(args) if not isinstance(a, Array)]
@@ -537,20 +537,20 @@ def map_blocks(func, *args, **kwargs):
 
     numblocks = list(arrs[0].numblocks)
 
-    if drop_dims:
+    if drop_axis:
         dsk = dict((tuple(k for i, k in enumerate(k)
-                             if i - 1 not in drop_dims), v)
+                             if i - 1 not in drop_axis), v)
                     for k, v in dsk.items())
-        numblocks = [n for i, n in enumerate(numblocks) if i not in drop_dims]
+        numblocks = [n for i, n in enumerate(numblocks) if i not in drop_axis]
 
-    if new_dims:
+    if new_axis:
         dsk, old_dsk = dict(), dsk
         for key in old_dsk:
             new_key = list(key)
-            for i in new_dims:
+            for i in new_axis:
                 new_key.insert(i + 1, 0)
             dsk[tuple(new_key)] = old_dsk[key]
-        for i in sorted(new_dims, reverse=False):
+        for i in sorted(new_axis, reverse=False):
             numblocks.insert(i, 1)
 
     if chunks is not None and chunks and not isinstance(chunks[0], tuple):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1361,6 +1361,9 @@ def test_map_blocks3():
     assert eq(res, x + 2*z)
     assert same_keys(da.core.map_blocks(func, d, f, dtype=d.dtype), res)
 
+    assert eq(da.map_blocks(func, f, d, dtype=d.dtype),
+              z + 2*x)
+
 
 def test_from_array_with_missing_chunks():
     x = np.random.randn(2, 4, 3)
@@ -1640,3 +1643,21 @@ def test_map_blocks_with_changed_dimension():
     assert e.ndim == 4
     assert e.chunks == ((1,), (4, 4), (4, 4), (1,))
     assert eq(e, x[None, :, :, None])
+
+
+def test_broadcast_chunks():
+    assert broadcast_chunks(((5, 5),), ((5, 5),)) == ((5, 5),)
+
+    a = ((10, 10, 10), (5, 5),)
+    b = ((5, 5),)
+    assert broadcast_chunks(a, b) == ((10, 10, 10), (5, 5),)
+    assert broadcast_chunks(b, a) == ((10, 10, 10), (5, 5),)
+
+    a = ((10, 10, 10), (5, 5),)
+    b = ((1,), (5, 5),)
+    assert broadcast_chunks(a, b) == ((10, 10, 10), (5, 5),)
+
+    a = ((10, 10, 10), (5, 5),)
+    b = ((3, 3,), (5, 5),)
+    with pytest.raises(ValueError):
+        broadcast_chunks(a, b)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -740,6 +740,13 @@ def test_map_blocks_with_constants():
               10 - np.arange(10))
 
 
+def test_map_blocks_with_kwargs():
+    d = da.arange(10, chunks=5)
+
+    assert eq(d.map_blocks(np.max, axis=0, keepdims=True, dtype=d.dtype),
+              np.array([4, 9]))
+
+
 def test_fromfunction():
     def f(x, y):
         return x + y

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 pytest.importorskip('numpy')
 
-from operator import add
+from operator import add, sub
 from tempfile import mkdtemp
 import shutil
 import os
@@ -726,6 +726,18 @@ def test_map_blocks2():
 
     assert eq(out, expected)
     assert same_keys(d.map_blocks(func, dtype='i8'), out)
+
+
+def test_map_blocks_with_constants():
+    d = da.arange(10, chunks=3)
+    e = d.map_blocks(add, 100, dtype=d.dtype)
+
+    assert eq(e, np.arange(10) + 100)
+
+    assert eq(da.map_blocks(sub, d, 10, dtype=d.dtype),
+              np.arange(10) - 10)
+    assert eq(da.map_blocks(sub, 10, d, dtype=d.dtype),
+              10 - np.arange(10))
 
 
 def test_fromfunction():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1630,7 +1630,7 @@ def test_map_blocks_with_changed_dimension():
     x = np.arange(56).reshape((7, 8))
     d = da.from_array(x, chunks=(7, 4))
 
-    e = d.map_blocks(lambda b: b.sum(axis=0), chunks=(4,), drop_dims=0,
+    e = d.map_blocks(lambda b: b.sum(axis=0), chunks=(4,), drop_axis=0,
                      dtype=d.dtype)
     assert e.ndim == 1
     assert e.chunks == ((4, 4),)
@@ -1639,7 +1639,7 @@ def test_map_blocks_with_changed_dimension():
     x = np.arange(64).reshape((8, 8))
     d = da.from_array(x, chunks=(4, 4))
     e = d.map_blocks(lambda b: b[None, :, :, None],
-                     chunks=(1, 4, 4, 1), new_dims=[0, 3], dtype=d.dtype)
+                     chunks=(1, 4, 4, 1), new_axis=[0, 3], dtype=d.dtype)
     assert e.ndim == 4
     assert e.chunks == ((1,), (4, 4), (4, 4), (1,))
     assert eq(e, x[None, :, :, None])


### PR DESCRIPTION
This allows `map_blocks` to support functions that create or destroy dimensions.  

Example
-------

```python
In [1]: import dask.array as da

In [2]: x = da.arange(16, chunks=(8,))

In [3]: y = x.map_blocks(lambda blk: blk.reshape((2, 2, 2)), chunks=(2, 2, 2), new_dims=[1, 2])

In [4]: y
Out[4]: dask.array<atop-3b..., shape=(4, 2, 2), dtype=None, chunksize=(2, 2, 2)>

In [5]: y.compute()
Out[5]:
array([[[ 0,  1],
        [ 2,  3]],

       [[ 4,  5],
        [ 6,  7]],

       [[ 8,  9],
        [10, 11]],

       [[12, 13],
        [14, 15]]])
```

cc @alimanfoo @shoyer