### PR TITLE
add test for h5py tokenization

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1586,3 +1586,19 @@ def test_view_fortran():
     d = da.from_array(x, chunks=(2, 3))
     assert eq(x.view('i4'), d.view('i4', order='F'))
     assert eq(x.view('i2'), d.view('i2', order='F'))
+
+
+def test_h5py_tokenize():
+    h5py = pytest.importorskip('h5py')
+    with tmpfile('hdf5') as fn1:
+        with tmpfile('hdf5') as fn2:
+            f = h5py.File(fn1)
+            g = h5py.File(fn2)
+
+            f['x'] = np.arange(10).astype(float)
+            g['x'] = np.ones(10).astype(float)
+
+            x1 = f['x']
+            x2 = g['x']
+
+            assert tokenize(x1) != tokenize(x2)


### PR DESCRIPTION
This question came up on the mailing list.  Turns out its already fixed in master via https://github.com/blaze/dask/pull/830

Adding the test anyway