### PR TITLE
Dot graph filename

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -199,7 +199,7 @@ def dot_graph(dsk, filename='mydask', format=None, **kwargs):
     """
     g = to_graphviz(dsk, **kwargs)
 
-    fmts = ['png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg']
+    fmts = ['.png', '.pdf', '.dot', '.svg', '.jpeg', '.jpg']
     if format is None and any(filename.lower().endswith(fmt) for fmt in fmts):
         format = filename.lower().split('.')[-1]
         filename = filename.rsplit('.')[0]

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -134,3 +134,25 @@ def test_dot_graph_defaults():
         assert isinstance(result, Image)
     finally:
         ensure_not_exists(target)
+
+
+def test_filenames_and_formats():
+    # Test with a variety of user provided args
+    filenames = ['mydaskpdf', 'mydask.pdf', 'mydask.pdf', 'mydaskpdf']
+    formats = ['svg', None, 'svg', None]
+    targets = ['mydaskpdf.svg', 'mydask.pdf', 'mydask.pdf.svg', 'mydaskpdf.png']
+
+    result_types = {
+        'png': Image,
+        'jpeg': Image,
+        'dot': type(None),
+        'pdf': type(None),
+        'svg': SVG,
+    }
+
+    for filename, format, target in zip(filenames, formats, targets):
+        expected_result_type = result_types[target.split('.')[-1]]
+        result = dot_graph(dsk, filename=filename, format=format)
+        assert os.path.isfile(target)
+        assert isinstance(result, expected_result_type)
+        ensure_not_exists(target)


### PR DESCRIPTION
Hi all, I am new to dask and also new to contributing to an open source project.

I noticed some inconsistent behavior in calling `dot_graph`.   In particular when called as 

`dot_graph(dsk, filename="mydaskpdf", format=None)` 

a `ValueError` exception was raised: `"Unknown format 'mydaskpdf' passed to 'dot_graph'"`.   Per the docstring, I was expecting the output to be saved as 'mydaskpdf.png', defaulting to the 'png' format.  

I believe the problem is in the definition of `dot_graph`.  I have added a simple test and a fix below.  I pushed to my fork and checked Travis.  All tests are passing after my minor change.  

This is the first time I send a pull request, so if I did something wrong please let me know.  

