### PR TITLE
Allow 'block_id' parameter to also be a keyword-only parameter

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -454,9 +454,16 @@ def map_blocks(func, *arrs, **kwargs):
         spec = getargspec(func)
     except:
         spec = None
-    if spec and 'block_id' in spec.args + spec.kwonlyargs:
-        for k in core.flatten(result._keys()):
-            result.dask[k] = (partial(func, block_id=k[1:]),) + result.dask[k][1:]
+    if spec:
+        args = spec.args
+        try:
+            args += spec.kwonlyargs
+        except AttributeError:
+            pass
+        if 'block_id' in args:
+            for k in core.flatten(result._keys()):
+                result.dask[k] = (partial(func, block_id=k[1:]),)\
+                                 + result.dask[k][1:]
 
     # Assert user specified chunks
     chunks = kwargs.get('chunks')

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -454,7 +454,7 @@ def map_blocks(func, *arrs, **kwargs):
         spec = getargspec(func)
     except:
         spec = None
-    if spec and 'block_id' in spec.args:
+    if spec and 'block_id' in spec.args + spec.kwonlyargs:
         for k in core.flatten(result._keys()):
             result.dask[k] = (partial(func, block_id=k[1:]),) + result.dask[k][1:]
 


### PR DESCRIPTION
In cases when the mapped function has unspecified number of array parameters, the 'block_id' parameter will be a keyword-only parameter as the last parameter. For example, in case
```python
def func(*arrays, block_id=None):
    pass
```
inspection on `func` returns 'block_id' as a keyword-only argument. When calling `array.map_blocks` block_id then does not work.