### PR TITLE
Force hdf key to have front slash

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -709,6 +709,7 @@ def read_hdf(pattern, key, start=0, stop=None, columns=None,
 
     >>> dd.read_hdf('myfile.1.hdf5', '/*')  # doctest: +SKIP
     """
+    key = key if key.startswith('/')  else '/' + key
     paths = sorted(glob(pattern))
     if (start != 0 or stop is not None) and len(paths) > 1:
         raise NotImplementedError(read_hdf_error_msg)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -516,7 +516,7 @@ def test_read_hdf():
     with tmpfile('h5') as fn:
         df.to_hdf(fn, '/data')
         try:
-            dd.read_hdf(fn, '/data', chunksize=2)
+            dd.read_hdf(fn, 'data', chunksize=2)
             assert False
         except TypeError as e:
             assert "format='table'" in str(e)


### PR DESCRIPTION
Fixes #858

```python
In [1]: import numpy as np
In [2]: import pandas as pd
In [3]: df = pd.DataFrame(np.random.random((1000, 1000)))

In [4]: import dask.dataframe as dd
In [5]: ddf = dd.from_pandas(df, 3)

In [6]: ddf.to_hdf('testhdf4.h5', key='my_df')
In [7]: ddf2 = dd.read_hdf('testhdf4.h5', 'my_df')

In [8]: import pandas.util.testing as tm
In [9]: tm.assert_frame_equal(ddf2.compute(), df)

In [10]: 
```

cc @fjanoos