### PR TITLE
Adjust memory bounds on ResourceProfiler plot

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -306,7 +306,8 @@ def plot_resources(results, palette='GnBu', **kwargs):
     colors = brewer[palette][6]
     p.line(t, cpu, color=colors[0], line_width=4, legend='% CPU')
     p.yaxis.axis_label = "% CPU"
-    p.extra_y_ranges = {'memory': Range1d(start=0, end=(max(mem) if mem else 100))}
+    p.extra_y_ranges = {'memory': Range1d(start=(min(mem) if mem else 0),
+                                          end=(max(mem) if mem else 100))}
     p.line(t, mem, color=colors[2], y_range_name='memory', line_width=4,
            legend='Memory')
     p.add_layout(LinearAxis(y_range_name='memory', axis_label='Memory (MB)'),


### PR DESCRIPTION
Now lower bound of memory axis is the minimum value, instead of 0. Fixes #840.
<img width="827" alt="screen shot 2015-12-03 at 1 47 26 pm" src="https://cloud.githubusercontent.com/assets/2783717/11571966/939eb1f4-99c4-11e5-886f-e3d6e6159a39.png">
