### PR TITLE
Replace dill with cloudpickle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then conda install numpy=1.9.2 pandas=0.16.2 pytables=3.2.0 h5py=2.5.0 bcolz=0.10.0 pytest coverage toolz scikit-learn cytoolz dill ipython chest blosc cython psutil mock; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then conda install numpy pandas pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz dill ipython chest blosc cython psutil mock; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then conda install numpy=1.9.2 pandas=0.16.2 pytables=3.2.0 h5py=2.5.0 bcolz=0.10.0 pytest coverage toolz scikit-learn cytoolz dill cloudpickle ipython chest blosc cython psutil mock; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then conda install numpy pandas pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz dill cloudpickle ipython chest blosc cython psutil mock; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then conda install bokeh; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade

--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ a light weight dependency.
 
 ``dask.array`` depends on ``numpy``.
 
-``dask.bag`` depends on ``toolz`` and ``dill``.
+``dask.bag`` depends on ``toolz`` and ``cloudpickle``.
 
 
 Examples

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - toolz
     - numpy
     - pandas
-    - dill
+    - cloudpickle
     - partd
     - chest
 

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -2,12 +2,12 @@ import pytest
 pytest.importorskip('numpy')
 
 import numpy as np
-import dill
 from dask.array.core import Array
 from dask.array.random import random, exponential, normal
 import dask.array as da
 import dask
 from dask.multiprocessing import get as mpget
+from dask.multiprocessing import _dumps, _loads
 
 
 def test_RandomState():
@@ -37,7 +37,7 @@ def test_serializability():
     state = da.random.RandomState(5)
     x = state.normal(10, 1, size=10, chunks=5)
 
-    y = dill.loads(dill.dumps(x))
+    y = _loads(_dumps(x))
 
     assert (x.compute() == y.compute()).all()
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from sys import getdefaultencoding
 
 import pytest
-pytest.importorskip('dill')
 
 from toolz import (merge, join, pipe, filter, identity, merge_with, take,
         partial, valmap)

--- a/dask/context.py
+++ b/dask/context.py
@@ -21,7 +21,8 @@ class set_options(object):
         pool - a thread or process pool
         cache - Cache to use for intermediate results
         func_loads/func_dumps - loads/dumps functions for serialization of data
-            likely to contain functions.  Defaults to dill.loads/dill.dumps
+            likely to contain functions.  Defaults to
+            cloudpickle.loads/cloudpickle.dumps
         rerun_exceptions_locally - rerun failed tasks in master process
 
     Examples

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1849,6 +1849,19 @@ def test_dataframe_series_are_dillable():
     f = dill.loads(dill.dumps(e))
     assert eq(e, f)
 
+def test_dataframe_series_are_pickleable():
+    try:
+        import cloudpickle
+        import pickle
+    except ImportError:
+        return
+
+    dumps = cloudpickle.dumps
+    loads = pickle.loads
+
+    e = d.groupby(d.a).b.sum()
+    f = loads(dumps(e))
+    assert eq(e, f)
 
 def test_random_partitions():
     a, b = d.random_split([0.5, 0.5])

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -3,14 +3,16 @@ from __future__ import absolute_import, division, print_function
 from toolz import curry, pipe, partial
 from .optimize import fuse, cull
 import multiprocessing
-import dill
+import cloudpickle
 import pickle
 from .async import get_async # TODO: get better get
 from .context import _globals
 
 
-_dumps = dill.dumps
-_loads = dill.loads
+def _dumps(x):
+        return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+
+_loads = pickle.loads
 
 
 def _process_get_id():

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from toolz import curry, pipe, partial
 from .optimize import fuse, cull
 import multiprocessing
-import dill
 import cloudpickle
 import pickle
 from .async import get_async # TODO: get better get
@@ -47,11 +46,11 @@ def get(dsk, keys, optimizations=[], num_workers=None,
     num_workers: int
         Number of worker processes (defaults to number of cores)
     func_dumps: function
-        Function to use for function serialization (defaults to
-        cloudpickle.dumps)
+        Function to use for function serialization
+        (defaults to cloudpickle.dumps)
     func_loads: function
-        Function to use for function deserialization (defaults to
-        cloudpickle.loads)
+        Function to use for function deserialization
+        (defaults to cloudpickle.loads)
     """
     pool = _globals['pool']
     if pool is None:

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, division, print_function
 from toolz import curry, pipe, partial
 from .optimize import fuse, cull
 import multiprocessing
-import cloudpickle
 import pickle
+import cloudpickle
+import dill
 from .async import get_async # TODO: get better get
 from .context import _globals
 from sys import getrecursionlimit, setrecursionlimit
@@ -13,15 +14,9 @@ def _dumps(x):
     try:
         return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
     except:
-        try:
-            recursionlimit = getrecursionlimit()
-            setrecursionlimit(2*recursionlimit)
-            dumped = cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
-            setrecursionlimit(recursionlimit)
-            return dumped
-        except:
-            raise
-
+        # note that the dill import should make pickle work for
+        # method_descriptor objects in python 2.x
+        return pickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
 
 _loads = pickle.loads
 

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -3,14 +3,26 @@ from __future__ import absolute_import, division, print_function
 from toolz import curry, pipe, partial
 from .optimize import fuse, cull
 import multiprocessing
+import dill
 import cloudpickle
 import pickle
 from .async import get_async # TODO: get better get
 from .context import _globals
-
+from sys import getrecursionlimit, setrecursionlimit
 
 def _dumps(x):
+    try:
         return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+    except:
+        try:
+            recursionlimit = getrecursionlimit()
+            setrecursionlimit(2*recursionlimit)
+            dumped = cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+            setrecursionlimit(recursionlimit)
+            return dumped
+        except:
+            raise
+
 
 _loads = pickle.loads
 

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -7,6 +7,7 @@ import multiprocessing
 import pickle
 from operator import add
 from dask.utils import raises
+import numpy as np
 
 inc = lambda x: x + 1
 
@@ -19,6 +20,16 @@ def test_apply_lambda():
         assert result.get() == 2
     finally:
         p.close()
+
+
+def test_pickle_globals():
+    """ For the function f(x) defined below, the only globals added in pickling
+    should be 'np' and '__builtins__'"""
+    def f(x):
+        return np.sin(x) + np.cos(x)
+
+    assert set(['np', '__builtins__']) == set(
+        _loads(_dumps(f)).__globals__.keys())
 
 
 def bad():

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -1,14 +1,12 @@
 import pytest
-pytest.importorskip('dill')
 
-from dask.multiprocessing import get, dill_apply_async
+from dask.multiprocessing import get, pickle_apply_async
+from dask.multiprocessing import _dumps, _loads
 from dask.context import set_options
 import multiprocessing
-import dill
 import pickle
 from operator import add
 from dask.utils import raises
-
 
 inc = lambda x: x + 1
 
@@ -16,7 +14,7 @@ inc = lambda x: x + 1
 def test_apply_lambda():
     p = multiprocessing.Pool()
     try:
-        result = dill_apply_async(p.apply_async, lambda x: x + 1, args=[1])
+        result = pickle_apply_async(p.apply_async, lambda x: x + 1, args=[1])
         assert isinstance(result, multiprocessing.pool.ApplyResult)
         assert result.get() == 2
     finally:

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
 numpydoc
 toolz
-dill
+cloudpickle
 pandas>=0.16.0

--- a/docs/source/bag.rst
+++ b/docs/source/bag.rst
@@ -208,9 +208,9 @@ Dask.bag uses partd_ to perform efficient, parallel, spill-to-disk shuffles.
 Function Serialization and Error Handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Dask.bag uses dill_ to serialize functions to send to worker processes.  Dill
-supports almost any kind of function, including lambdas, closures, partials
-and functions defined interactively.
+Dask.bag uses cloudpickle_ to serialize functions to send to worker processes.
+cloudpickle supports almost any kind of function, including lambdas, closures,
+partials and functions defined interactively.
 
 When an error occurs in a remote process the dask schedulers record the
 Exception and the traceback and delivers these to the main process.  These
@@ -234,7 +234,7 @@ default get function to the synchronous single-core scheduler
    >>> dask.set_options(get=get_sync)  # set global
    >>> list(b)  # uses synchronous scheduler
 
-.. _dill: http://trac.mystic.cacr.caltech.edu/project/pathos/wiki/dill
+.. _cloudpickle: https://github.com/cloudpipe/cloudpickle
 
 
 Known Limitations

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -17,7 +17,7 @@ Install parts of dask
 Different components of dask have different dependencies that are only relevant for that component.
 
 * ``dask.array``: numpy
-* ``dask.bag``: dill
+* ``dask.bag``: cloudpickle
 * ``dask.dataframe``: pandas, bcolz (in development)
 
 The base ``pip`` install of dask is fairly minimal.  This is to protect

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import dask
 
 extras_require = {
   'array': ['numpy', 'toolz >= 0.7.2'],
-  'bag': ['dill', 'toolz >= 0.7.2', 'partd >= 0.3.2'],
+  'bag': ['cloudpickle', 'toolz >= 0.7.2', 'partd >= 0.3.2'],
   'dataframe': ['numpy', 'pandas >= 0.16.0', 'toolz >= 0.7.2', 'partd >= 0.3.2'],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
WIP for #847 

* updated docs, travis, and conda.recipe to use `cloudpickle`.  

* left dill in the travis installs because `test_dataframe_series_are_dillable` uses it

* centralized the choice between `dill` and `cloudpickle` at `dask/multiprocessing.py`.   Other tests where `dill` was imported now use `multiprocessing._dumps` and `multiprocessing._loads`. 

* added a test for pickling functions with `__globals__`: `dask/tests/test_multiprocessing.py::test_pickle_globals`. 
    - The test fails with `dill` and passes with `cloudpickle`

* the switch to `cloudpickle` introduced regressions in some tests for Python <= 3.3
    - `dask/bag/core.py::dask.bag.core.Bag.distinct FAILED`  (failed in Python:2.7 only)
    - `dask/bag/tests/test_bag.py::test_fold FAILED`
    - `dask/bag/tests/test_bag.py::test_distinct FAILED`
    - `dask/bag/tests/test_bag.py::test_from_filenames_large FAILED `
    - `dask/bag/tests/test_bag.py::test_from_filenames_encoding FAILED`
    - `dask/bag/tests/test_bag.py::test_from_filenames_large_gzip FAILED`

* the error seen in the FAILED tests above was always: `PicklingError: Could not pickle object as excessively deep recursion required.`
* I introduced a somewhat ugly hack in `dask/multiprocessing.py` that fixes the recursion errors seen so far:  if `dumps` fails the recursion limit is increased by a factor of 2 and `cloudpickle` tries again. 

I appreciate any feedback on this WIP.   Thanks! 
