### PR TITLE
Forward kwargs to compute to both get and optimize

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1727,3 +1727,8 @@ def test_chunks_error():
     x = np.ones((10, 10))
     with pytest.raises(ValueError):
         da.from_array(x, chunks=(5,))
+
+
+def test_array_compute_forward_kwargs():
+    x = da.arange(10, chunks=2).sum()
+    x.compute(bogus_keyword=10)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -97,7 +97,7 @@ def inline_singleton_lists(dsk):
     return inline(dsk, keys, inline_constants=False)
 
 
-def optimize(dsk, keys):
+def optimize(dsk, keys, **kwargs):
     """ Optimize a dask from a dask.bag """
     dsk2 = cull(dsk, keys)
     dsk3 = fuse(dsk2)

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -690,3 +690,8 @@ def test_gh715():
             f.write(bin_data)
         a = db.from_filenames(fn)
         assert a.compute()[0] == bin_data.decode('utf-8')
+
+
+def test_bag_compute_forward_kwargs():
+    x = db.from_sequence([1, 2, 3]).map(lambda a: a + 1)
+    x.compute(bogus_keyword=10)

--- a/dask/base.py
+++ b/dask/base.py
@@ -39,7 +39,7 @@ class Base(object):
     @classmethod
     def _get(cls, dsk, keys, get=None, **kwargs):
         get = get or _globals['get'] or cls._default_get
-        dsk2 = cls._optimize(dsk, keys)
+        dsk2 = cls._optimize(dsk, keys, **kwargs)
         return get(dsk2, keys, **kwargs)
 
     @classmethod
@@ -104,7 +104,7 @@ def compute(*args, **kwargs):
                              "the `get` kwarg or globally with `set_options`.")
 
     dsk = merge([opt(merge([v.dask for v in val]),
-                     [v._keys() for v in val])
+                     [v._keys() for v in val], **kwargs)
                 for opt, val in groups.items()])
     keys = [var._keys() for var in variables]
     results = get(dsk, keys, **kwargs)

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -55,9 +55,9 @@ def _concat(args, **kwargs):
     return args
 
 
-def optimize(dsk, keys):
+def optimize(dsk, keys, **kwargs):
     from .optimize import optimize
-    return optimize(dsk, keys)
+    return optimize(dsk, keys, **kwargs)
 
 
 def finalize(self, results):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2373,3 +2373,8 @@ def test_reset_index():
     assert len(res.index.compute()) == len(exp.index)
     assert res.columns == tuple(exp.columns)
     assert_array_almost_equal(res.compute().values, exp.values)
+
+
+def test_dataframe_compute_forward_kwargs():
+    x = dd.from_pandas(pd.DataFrame({'a': range(10)}), npartitions=2).a.sum()
+    x.compute(bogus_keyword=10)

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -214,7 +214,7 @@ class Value(base.Base):
     Equivalent to the output from a single key in a dask graph.
     """
     __slots__ = ('_key', '_dasks')
-    _optimize = staticmethod(lambda dsk, keys: dsk)
+    _optimize = staticmethod(lambda dsk, keys, **kwargs: dsk)
     _finalize = staticmethod(lambda a, r: r[0])
     _default_get = staticmethod(threaded.get)
 

--- a/dask/tests/test_imperative.py
+++ b/dask/tests/test_imperative.py
@@ -229,3 +229,8 @@ def test_value_picklable():
     y = pickle.loads(pickle.dumps(x))
     assert x.dask == y.dask
     assert x._key == y._key
+
+
+def test_imperative_compute_forward_kwargs():
+    x = value(1) + 2
+    x.compute(bogus_keyword=10)


### PR DESCRIPTION
Now

```
x.compute(some_kwarg_here='foo')
```

Gets forwarded to both `x._optimize` and `x._get`. This allows fine tuning of both steps of the compute process when using dask collections. Came up in discussion of #874.