### PR TITLE
DOC: Fix Array.cache examples

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -880,6 +880,9 @@ class Array(Base):
         kwargs:
             Keyword arguments to pass on to ``get`` function for scheduling
 
+        Examples
+        --------
+
         This triggers evaluation and store the result in either
 
         1.  An ndarray object supporting setitem (see da.store)


### PR DESCRIPTION
Currently docstring examples are not rendered properly.

http://dask.pydata.org/en/latest/array-api.html#dask.array.core.Array.cache