### PR TITLE
Implement dask.dataframe.iterrows and dask.dataframe.itertuples

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -986,6 +986,13 @@ class Series(_Frame):
     def _get_numeric_data(self, how='any', subset=None):
         return self
 
+    @derived_from(pd.Series)
+    def iteritems(self):
+        for i in range(self.npartitions):
+            s = self.get_division(i).compute()
+            for item in s.iteritems():
+                yield item
+
     @classmethod
     def _validate_axis(cls, axis=0):
         if axis not in (0, 'index', None):
@@ -1461,6 +1468,20 @@ class DataFrame(_Frame):
         elif isinstance(other, pd.Series):
             other = other.to_frame().T
         return super(DataFrame, self).append(other)
+
+    @derived_from(pd.DataFrame)
+    def iterrows(self):
+        for i in range(self.npartitions):
+            df = self.get_division(i).compute()
+            for row in df.iterrows():
+                yield row
+
+    @derived_from(pd.DataFrame)
+    def itertuples(self):
+        for i in range(self.npartitions):
+            df = self.get_division(i).compute()
+            for row in df.itertuples():
+                yield row
 
     @classmethod
     def _bind_operator_method(cls, name, op):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2391,3 +2391,23 @@ def test_reset_index():
 def test_dataframe_compute_forward_kwargs():
     x = dd.from_pandas(pd.DataFrame({'a': range(10)}), npartitions=2).a.sum()
     x.compute(bogus_keyword=10)
+
+def test_series_iteritems():
+    df = pd.DataFrame({'x': [1, 2, 3, 4]})
+    ddf = dd.from_pandas(df, npartitions=2)
+    for (a, b) in zip(df['x'].iteritems(), ddf['x'].iteritems()):
+        assert a == b
+
+def test_dataframe_iterrows():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    for (a, b) in zip(df.iterrows(), ddf.iterrows()):
+        tm.assert_series_equal(a[1], b[1])
+
+def test_dataframe_itertuples():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [10, 20, 30, 40]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    for (a, b) in zip(df.itertuples(), ddf.itertuples()):
+        assert a == b


### PR DESCRIPTION
Implement dataframe.iterrows() and dataframe.itertuples() for iterating over each row of a Dask DataFrame, similar to the corresponding methods in pandas.DataFrame.