### PR TITLE
ENH: Add LU decomposition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then conda install numpy=1.9.2 pandas=0.16.2 pytables=3.2.0 h5py=2.5.0 bcolz=0.10.0 pytest coverage toolz scikit-learn cytoolz dill cloudpickle ipython chest blosc cython psutil mock; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then conda install numpy pandas pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz dill cloudpickle ipython chest blosc cython psutil mock; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then conda install numpy=1.9.2 scipy pandas=0.16.2 pytables=3.2.0 h5py=2.5.0 bcolz=0.10.0 pytest coverage toolz scikit-learn cytoolz dill cloudpickle ipython chest blosc cython psutil mock; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then conda install numpy scipy pandas pytables h5py bcolz pytest coverage toolz scikit-learn cytoolz dill cloudpickle ipython chest blosc cython psutil mock; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then conda install bokeh; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -27,6 +27,7 @@ if PY3:
         else:
             return func(*args)
     range = range
+    reduce = functools.reduce
     operator_div = operator.truediv
 
     def _getargspec(func):
@@ -47,6 +48,7 @@ else:
     long = long
     apply = apply
     range = xrange
+    reduce = reduce
     operator_div = operator.div
 
     def _getargspec(func):


### PR DESCRIPTION
It is still under work. I'm going to built ``scipy.linalg.lu`` compat API using blocked gaussian elimination.

```
A = np.array([[7, 3, -1, 2], [3, 8, 1, -4], [-1, 1, 4, -1], [2, -4, -1, 6] ])
A
# array([[ 7,  3, -1,  2],
#        [ 3,  8,  1, -4],
#        [-1,  1,  4, -1],
#        [ 2, -4, -1,  6]])

dA = da.from_array(A, chunks=(2, 2))
dA
# dask.array<from-ar..., shape=(4, 4), dtype=int64, chunksize=(2, 2)>

p, l, u = da.linalg.lu(dA)
l
# dask.array<lu-l-6d..., shape=(4, 4), dtype=int64, chunksize=(2, 2)>

p.compute()
# array([[ 1.,  0.,  0.,  0.],
#        [ 0.,  1.,  0.,  0.],
#        [ 0.,  0.,  1.,  0.],
#        [ 0.,  0.,  0.,  1.]])

l.compute()
# array([[ 1.        ,  0.        ,  0.        ,  0.        ],
#        [ 0.42857143,  1.        ,  0.        ,  0.        ],
#        [-0.14285714,  0.21276596,  1.        ,  0.        ],
#        [ 0.28571429, -0.72340426,  0.08982036,  1.        ]])

u.compute()
# array([[ 7.        ,  3.        , -1.        ,  2.        ],
#        [ 0.        ,  6.71428571,  1.42857143, -4.85714286],
#        [ 0.        ,  0.        ,  3.55319149,  0.31914894],
#        [ 0.        ,  0.        ,  0.        ,  1.88622754]])
```

## scipy results

```
p, l, u = scipy.linalg.lu(A)
p
# array([[ 1.,  0.,  0.,  0.],
#        [ 0.,  1.,  0.,  0.],
#        [ 0.,  0.,  1.,  0.],
#        [ 0.,  0.,  0.,  1.]])

l
# array([[ 1.        ,  0.        ,  0.        ,  0.        ],
#        [ 0.42857143,  1.        ,  0.        ,  0.        ],
#        [-0.14285714,  0.21276596,  1.        ,  0.        ],
#        [ 0.28571429, -0.72340426,  0.08982036,  1.        ]])

u
# array([[ 7.        ,  3.        , -1.        ,  2.        ],
#        [ 0.        ,  6.71428571,  1.42857143, -4.85714286],
#        [ 0.        ,  0.        ,  3.55319149,  0.31914894],
#        [ 0.        ,  0.        ,  0.        ,  1.88622754]])
```
