### PR TITLE
Avoid including dask collection within dask graph

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -729,11 +729,16 @@ def blockdims_from_blockshape(shape, chunks):
                               for d, bd in zip(shape, chunks))
 
 
-def finalize(arr, results):
-    if arr.shape:
+def finalize(results):
+    if not results:
         return concatenate3(results)
-    else:
-        return unpack_singleton(results)
+    results2 = results
+    while isinstance(results2, (tuple, list)):
+        if len(results2) > 1:
+            return concatenate3(results)
+        else:
+            results2 = results2[0]
+    return unpack_singleton(results)
 
 
 class Array(Base):
@@ -1640,7 +1645,7 @@ def unpack_singleton(x):
     >>> unpack_singleton(np.array(np.datetime64('2000-01-01')))
     array(datetime.date(2000, 1, 1), dtype='datetime64[D]')
     """
-    while True:
+    while isinstance(x, (list, tuple)):
         try:
             x = x[0]
         except (IndexError, TypeError, KeyError):

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -174,9 +174,7 @@ def to_textfiles(b, path, name_function=str, encoding=system_encoding):
     return Bag(merge(b.dask, dsk), name, b.npartitions)
 
 
-def finalize(bag, results):
-    if isinstance(bag, Item):
-        return results[0]
+def finalize(results):
     if isinstance(results, Iterator):
         results = list(results)
     if isinstance(results[0], Iterable) and not isinstance(results[0], str):
@@ -186,10 +184,14 @@ def finalize(bag, results):
     return results
 
 
+def finalize_item(results):
+    return results[0]
+
+
 class Item(Base):
     _optimize = staticmethod(optimize)
     _default_get = staticmethod(mpget)
-    _finalize = staticmethod(finalize)
+    _finalize = staticmethod(finalize_item)
 
     def __init__(self, dsk, key):
         self.dask = dsk

--- a/dask/base.py
+++ b/dask/base.py
@@ -111,7 +111,7 @@ def compute(*args, **kwargs):
 
     results_iter = iter(results)
     return tuple(a if not isinstance(a, Base)
-                   else a._finalize(a, next(results_iter))
+                   else a._finalize(next(results_iter))
                    for a in args)
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -60,7 +60,7 @@ def optimize(dsk, keys, **kwargs):
     return optimize(dsk, keys, **kwargs)
 
 
-def finalize(self, results):
+def finalize(results):
     return _concat(results)
 
 
@@ -730,7 +730,8 @@ class _Frame(Base):
 
     @derived_from(pd.DataFrame)
     def cumsum(self, axis=None, skipna=True):
-        chunk = lambda x: self._partition_type.cumsum(x, axis=axis, skipna=skipna)
+        func = self._partition_type.cumsum
+        chunk = lambda x: func(x, axis=axis, skipna=skipna)
         return self._cum_agg('cumsum', chunk=chunk, aggregate=operator.add,
                              axis=axis, skipna=skipna)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -692,18 +692,21 @@ class _Frame(Base):
         return self._constructor(dsk, name, num.column_info,
                                  divisions=[None, None])
 
-    def _cum_agg(self, token, chunk, aggregate, axis, skipna=True):
+    def _cum_agg(self, token, chunk, aggregate, axis, skipna=True,
+                 chunk_kwargs=None):
         """ Wrapper for cumulative operation """
 
         axis = self._validate_axis(axis)
 
         if axis == 1:
             name = '{0}{1}(axis=1)'.format(self._token_prefix, token)
-            return map_partitions(chunk, self.column_info, self, token=name)
+            return map_partitions(chunk, self.column_info, self, token=name,
+                    **chunk_kwargs)
         else:
             # cumulate each partitions
             name1 = '{0}{1}-map'.format(self._token_prefix, token)
-            cumpart = map_partitions(chunk, self.column_info, self, token=name1)
+            cumpart = map_partitions(chunk, self.column_info, self,
+                    token=name1, **chunk_kwargs)
 
             name2 = '{0}{1}-take-last'.format(self._token_prefix, token)
             cumlast = map_partitions(_take_last, self.column_info, cumpart,
@@ -730,16 +733,19 @@ class _Frame(Base):
 
     @derived_from(pd.DataFrame)
     def cumsum(self, axis=None, skipna=True):
-        func = self._partition_type.cumsum
-        chunk = lambda x: func(x, axis=axis, skipna=skipna)
-        return self._cum_agg('cumsum', chunk=chunk, aggregate=operator.add,
-                             axis=axis, skipna=skipna)
+        return self._cum_agg('cumsum',
+                             chunk=self._partition_type.cumsum,
+                             aggregate=operator.add,
+                             axis=axis, skipna=skipna,
+                             chunk_kwargs=dict(axis=axis, skipna=skipna))
 
     @derived_from(pd.DataFrame)
     def cumprod(self, axis=None, skipna=True):
-        chunk = lambda x: self._partition_type.cumprod(x, axis=axis, skipna=skipna)
-        return self._cum_agg('cumprod', chunk=chunk, aggregate=operator.mul,
-                             axis=axis, skipna=skipna)
+        return self._cum_agg('cumprod',
+                             chunk=self._partition_type.cumprod,
+                             aggregate=operator.mul,
+                             axis=axis, skipna=skipna,
+                             chunk_kwargs=dict(axis=axis, skipna=skipna))
 
     @derived_from(pd.DataFrame)
     def cummax(self, axis=None, skipna=True):
@@ -748,9 +754,11 @@ class _Frame(Base):
                 return x.where((x > y) | x.isnull(), y, axis=x.ndim - 1)
             else:       # scalar
                 return x if x > y else y
-        chunk = lambda x: self._partition_type.cummax(x, axis=axis, skipna=skipna)
-        return self._cum_agg('cummax', chunk=chunk, aggregate=aggregate,
-                             axis=axis, skipna=skipna)
+        return self._cum_agg('cummax',
+                             chunk=self._partition_type.cummax,
+                             aggregate=aggregate,
+                             axis=axis, skipna=skipna,
+                             chunk_kwargs=dict(axis=axis, skipna=skipna))
 
     @derived_from(pd.DataFrame)
     def cummin(self, axis=None, skipna=True):
@@ -759,9 +767,11 @@ class _Frame(Base):
                 return x.where((x < y) | x.isnull(), y, axis=x.ndim - 1)
             else:       # scalar
                 return x if x < y else y
-        chunk = lambda x: self._partition_type.cummin(x, axis=axis, skipna=skipna)
-        return self._cum_agg('cummin', chunk=chunk, aggregate=aggregate,
-                             axis=axis, skipna=skipna)
+        return self._cum_agg('cummin',
+                             chunk=self._partition_type.cummin,
+                             aggregate=aggregate,
+                             axis=axis, skipna=skipna,
+                             chunk_kwargs=dict(axis=axis, skipna=skipna))
 
     @derived_from(pd.DataFrame)
     def where(self, cond, other=np.nan):

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -6,7 +6,7 @@ from itertools import chain, count
 import operator
 import uuid
 
-from toolz import merge, unique, curry
+from toolz import merge, unique, curry, first
 
 from .optimize import cull, fuse
 from .utils import concrete, funcname
@@ -71,7 +71,7 @@ def to_task_dasks(expr):
         name = tokenize(expr, pure=True)
         keys = expr._keys()
         dsk = expr._optimize(expr.dask, keys)
-        dsk[name] = (expr._finalize, expr, (concrete, keys))
+        dsk[name] = (expr._finalize, (concrete, keys))
         return name, [dsk]
     if isinstance(expr, tuple) and type(expr) != tuple:
         return expr, []
@@ -215,7 +215,7 @@ class Value(base.Base):
     """
     __slots__ = ('_key', '_dasks')
     _optimize = staticmethod(lambda dsk, keys, **kwargs: dsk)
-    _finalize = staticmethod(lambda r: r[0])
+    _finalize = staticmethod(first)
     _default_get = staticmethod(threaded.get)
 
     def __init__(self, name, dasks):

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -215,7 +215,7 @@ class Value(base.Base):
     """
     __slots__ = ('_key', '_dasks')
     _optimize = staticmethod(lambda dsk, keys, **kwargs: dsk)
-    _finalize = staticmethod(lambda a, r: r[0])
+    _finalize = staticmethod(lambda r: r[0])
     _default_get = staticmethod(threaded.get)
 
     def __init__(self, name, dasks):


### PR DESCRIPTION
Two main changes:

1.  `_finalize` no longer accepts the object itself (cc @jcrist )
2.  The cumulative aggregates in dask.dataframe no longer use lambdas that include `self` (cc @sinhrks)

These became troublesome when using collections with [distributed](http://distributed.readthedocs.org/en/latest/) where we communicate the graph between workers (requiring serialization) but the collections themselves weren't serializable