### PR TITLE
add @sisp to authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -32,6 +32,8 @@
 
 [sinhrks](https://github.com/sinhrks)
 
+[Sigurd Spieckermann](https://github.com/sisp)
+
 [Stuart Owen](http://stuartowen.com/)
 
 [Tom Augspurger](https://github.com/TomAugspurger)


### PR DESCRIPTION
@sisp do you have a name or other website that you would like to have included instead?  I couldn't find information from your github page to determine who you were.