### PR TITLE
Respect output keys in optimizations

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -65,8 +65,10 @@ def remove_full_slices(dsk, keys):
     {'a': (range, 5),
      'e': (getitem, 'a', (slice(None, 5, None),))}
     """
-    full_slice_keys = set(k for k, task in dsk.items() if is_full_slice(task))
-    dsk2 = dict((k, task[1] if k in full_slice_keys else task)
+    keys = set(keys)
+    full_slice_keys = set(k for k, task in dsk.items()
+                            if is_full_slice(task))
+    dsk2 = dict((k, task[1] if k in full_slice_keys and k not in keys else task)
                  for k, task in dsk.items())
     dsk3 = dealias(dsk2, keys)
     return dsk3

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -19,13 +19,13 @@ def optimize(dsk, keys, **kwargs):
     3.  Inline fast functions like getitem and np.transpose
     """
     keys = list(flatten(keys))
-    fast_functions=kwargs.get('fast_functions',
+    fast_functions = kwargs.get('fast_functions',
                              set([getarray, getitem, np.transpose]))
     dsk2 = cull(dsk, keys)
     dsk3 = remove_full_slices(dsk2, keys)
     dsk4 = fuse(dsk3, keys)
     dsk5 = valmap(rewrite_rules.rewrite, dsk4)
-    dsk6 = inline_functions(dsk5, fast_functions=fast_functions)
+    dsk6 = inline_functions(dsk5, keys, fast_functions=fast_functions)
     return dsk6
 
 

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -71,6 +71,14 @@ def test_optimize_slicing():
 
     assert remove_full_slices(dsk, []) == expected
 
+    # protect output keys
+    expected = {'a': (range, 10),
+                'c': (getarray, 'a', (slice(None, None, None),)),
+                'd': (getarray, 'c', (slice(None, 5, None),)),
+                'e': (getarray, 'd', (slice(None, None, None),))}
+
+    assert remove_full_slices(dsk, ['c', 'd', 'e']) == expected
+
 
 def test_fuse_slice():
     assert fuse_slice(slice(10, 15), slice(0, 5, 2)) == slice(10, 15, 2)

--- a/dask/core.py
+++ b/dask/core.py
@@ -157,7 +157,8 @@ def _deps(dsk, arg):
     ['x']
     >>> _deps(dsk, ['x', 'y'])
     ['x', 'y']
-
+    >>> _deps(dsk, {'a': 'x'})
+    ['x']
     >>> _deps(dsk, (add, 'x', (inc, 'y')))  # doctest: +SKIP
     ['x', 'y']
     """
@@ -168,6 +169,8 @@ def _deps(dsk, arg):
         return result
     if isinstance(arg, list):
         return sum([_deps(dsk, a) for a in arg], [])
+    if isinstance(arg, dict):
+        return sum([_deps(dsk, v) for v in arg.values()], [])
     try:
         if arg not in dsk:
             return []

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -281,7 +281,7 @@ def dealias(dsk, keys=None):
     aliases = set((k for k, task in dsk.items() if ishashable(task) and task in dsk))
     roots = set((k for k, v in dependents.items() if not v))
 
-    dsk2 = inline(dsk, aliases - roots, inline_constants=False)
+    dsk2 = inline(dsk, aliases - roots - keys, inline_constants=False)
     dsk3 = dsk2.copy()
 
     dependencies = dict((k, get_dependencies(dsk2, k)) for k in dsk2)

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -165,7 +165,7 @@ def inline(dsk, keys=None, inline_constants=True):
     return rv
 
 
-def inline_functions(dsk, fast_functions=None, inline_constants=False):
+def inline_functions(dsk, output, fast_functions=None, inline_constants=False):
     """ Inline cheap functions into larger operations
 
     Examples
@@ -174,13 +174,24 @@ def inline_functions(dsk, fast_functions=None, inline_constants=False):
     ...        'i': (inc, 'x'),
     ...        'd': (double, 'y'),
     ...        'x': 1, 'y': 1}
-    >>> inline_functions(dsk, [inc])  # doctest: +SKIP
+    >>> inline_functions(dsk, [], [inc])  # doctest: +SKIP
     {'out': (add, (inc, 'x'), 'd'),
      'd': (double, 'y'),
+     'x': 1, 'y': 1}
+
+    Protect output keys.  In the example below ``i`` is not inlined because it
+    is marked as an output key.
+
+    >>> inline_functions(dsk, ['i', 'out'], [inc, double])  # doctest: +SKIP
+    {'out': (add, 'i', (double, 'y')),
+     'i': (inc, 'x'),
      'x': 1, 'y': 1}
     """
     if not fast_functions:
         return dsk
+
+    output = set(output)
+
     fast_functions = set(fast_functions)
 
     dependencies = dict((k, get_dependencies(dsk, k)) for k in dsk)
@@ -189,7 +200,8 @@ def inline_functions(dsk, fast_functions=None, inline_constants=False):
     keys = [k for k, v in dsk.items()
               if istask(v)
               and functions_of(v).issubset(fast_functions)
-              and dependents[k]]
+              and dependents[k]
+              and k not in output]
     if keys:
         return inline(dsk, keys, inline_constants=inline_constants)
     else:

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -133,7 +133,7 @@ def test_inline_functions():
            d: (double, y),
            x: 1, y: 1}
 
-    result = inline_functions(dsk, fast_functions=set([inc]))
+    result = inline_functions(dsk, [], fast_functions=set([inc]))
     expected = {'out': (add, (inc, x), d),
                 d: (double, y),
                 x: 1, y: 1}
@@ -145,13 +145,13 @@ def test_inline_ignores_curries_and_partials():
            'a': (partial(add, 1), 'x'),
            'b': (inc, 'a')}
 
-    result = inline_functions(dsk, fast_functions=set([add]))
+    result = inline_functions(dsk, [], fast_functions=set([add]))
     assert 'a' not in set(result.keys())
 
 
 def test_inline_doesnt_shrink_fast_functions_at_top():
     dsk = {'x': (inc, 'y'), 'y': 1}
-    result = inline_functions(dsk, fast_functions=set([inc]))
+    result = inline_functions(dsk, [], fast_functions=set([inc]))
     assert result == dsk
 
 
@@ -164,8 +164,15 @@ def test_inline_traverses_lists():
     expected = {'out': (sum, [(inc, x), d]),
                 d: (double, y),
                 x: 1, y: 1}
-    result = inline_functions(dsk, fast_functions=set([inc]))
+    result = inline_functions(dsk, [], fast_functions=set([inc]))
     assert result == expected
+
+
+def test_inline_protects_output_keys():
+    dsk = {'x': (inc, 1), 'y': (double, 'x')}
+    assert inline_functions(dsk, [], [inc]) == {'y': (double, (inc, 1))}
+    assert inline_functions(dsk, ['x'], [inc]) == {'y': (double, 'x'),
+                                                   'x': (inc, 1)}
 
 
 def test_functions_of():


### PR DESCRIPTION
This serves #885 

In the dask.array optimization chain we were losing output keys in a few places.