### PR TITLE
Cumulative reductions

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -18,7 +18,8 @@ from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          moment,
                          argmin, argmax,
                          nansum, nanmean, nanstd, nanvar, nanmin,
-                         nanmax, nanargmin, nanargmax)
+                         nanmax, nanargmin, nanargmax,
+                         cumsum, cumprod)
 from .percentile import percentile
 with ignoring(ImportError):
     from .reductions import nanprod

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1289,6 +1289,16 @@ class Array(Base):
         from .ghost import map_overlap
         return map_overlap(self, func, depth, boundary, trim, **kwargs)
 
+    @wraps(np.ndarray.cumsum)
+    def cumsum(self, axis, dtype=None):
+        from .reductions import cumsum
+        return cumsum(self, axis, dtype)
+
+    @wraps(np.ndarray.cumprod)
+    def cumprod(self, axis, dtype=None):
+        from .reductions import cumprod
+        return cumprod(self, axis, dtype)
+
     @wraps(squeeze)
     def squeeze(self):
         return squeeze(self)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1289,13 +1289,13 @@ class Array(Base):
         from .ghost import map_overlap
         return map_overlap(self, func, depth, boundary, trim, **kwargs)
 
-    @wraps(np.ndarray.cumsum)
     def cumsum(self, axis, dtype=None):
+        """ See da.cumsum for docstring """
         from .reductions import cumsum
         return cumsum(self, axis, dtype)
 
-    @wraps(np.ndarray.cumprod)
     def cumprod(self, axis, dtype=None):
+        """ See da.cumprod for docstring """
         from .reductions import cumprod
         return cumprod(self, axis, dtype)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1781,3 +1781,23 @@ def test_to_imperative():
 
     [[a, b], [c, d]] = y.to_imperative()
     assert eq(a.compute(), y[:2, :2])
+
+
+def test_cumulative():
+    x = da.arange(20, chunks=5)
+    y = x.cumsum(axis=0)
+    eq(x.cumsum(axis=0), np.arange(20).cumsum())
+    eq(x.cumprod(axis=0), np.arange(20).cumprod())
+
+    a = np.random.random((20, 24))
+    x = da.from_array(a, chunks=(6, 5))
+    eq(x.cumsum(axis=0), a.cumsum(axis=0))
+    eq(x.cumsum(axis=1), a.cumsum(axis=1))
+    eq(x.cumprod(axis=0), a.cumprod(axis=0))
+    eq(x.cumprod(axis=1), a.cumprod(axis=1))
+
+    a = np.random.random((20, 24, 13))
+    x = da.from_array(a, chunks=(6, 5, 4))
+    for axis in [0, 1, 2]:
+        eq(x.cumsum(axis=axis), a.cumsum(axis=axis))
+        eq(x.cumprod(axis=axis), a.cumprod(axis=axis))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -476,13 +476,12 @@ class _Frame(Base):
             Fraction of axis items to return.
         replace: boolean, optional
             Sample with or without replacement. Default = False.
-        random_state: int or np.random.RandomState
-            If int create a new RandomState with this as the seed
-        Otherwise draw from the passed RandomState
+        random_state: int or ``np.random.RandomState``
+            If int we create a new RandomState with this as the seed
+            Otherwise we draw from the passed RandomState
 
         See Also
         --------
-
             dask.DataFrame.random_split, pd.DataFrame.sample
         """
 


### PR DESCRIPTION
Example
-------

```python
In [1]: import dask.array as da

In [2]: da.arange(12, chunks=4).cumsum(axis=0).compute()
Out[2]: array([ 0,  1,  3,  6, 26, 31, 37, 44, 68, 77, 87, 98])

n [3]: da.ones((5, 5), chunks=(3, 3)).cumsum(axis=0).compute()
Out[3]:
array([[ 1.,  1.,  1.,  1.,  1.],
       [ 2.,  2.,  2.,  2.,  2.],
       [ 3.,  3.,  3.,  3.,  3.],
       [ 3.,  3.,  3.,  3.,  3.],
       [ 4.,  4.,  4.,  4.,  4.]])

In [4]: da.ones((5, 5), chunks=(3, 3)).cumsum(axis=1).compute()
Out[4]:
array([[ 1.,  2.,  3.,  3.,  4.],
       [ 1.,  2.,  3.,  3.,  4.],
       [ 1.,  2.,  3.,  3.,  4.],
       [ 1.,  2.,  3.,  3.,  4.],
       [ 1.,  2.,  3.,  3.,  4.]])
```

Fixes #923

cc @pwolfram