### PR TITLE
ENH: Add da.tril and da.triu

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -13,7 +13,7 @@ from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         fmax, fmin, isreal, iscomplex, isfinite, isinf, isnan, signbit,
         copysign, nextafter, ldexp, fmod, floor, ceil, trunc, degrees, radians,
         rint, fix, angle, real, imag, clip, fabs, sign, frexp, modf, around,
-        isnull, notnull, isclose)
+        isnull, notnull, isclose, triu, tril)
 from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          moment,
                          argmin, argmax,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2670,6 +2670,106 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
             return n, bins
 
 
+def triu(m, k=0):
+    """
+    Upper triangle of an array with elements above the `k`-th diagonal zeroed.
+
+    Parameters
+    ----------
+    m : array_like, shape (M, N)
+        Input array.
+    k : int, optional
+        Diagonal above which to zero elements.  `k = 0` (the default) is the
+        main diagonal, `k < 0` is below it and `k > 0` is above.
+
+    Returns
+    -------
+    triu : ndarray, shape (M, N)
+        Upper triangle of `m`, of same shape and data-type as `m`.
+
+    See Also
+    --------
+    tril : lower triangle of an array
+    """
+    if m.ndim != 2:
+        raise ValueError('input must be 2 dimensional')
+    if m.shape[0] != m.shape[1]:
+        raise NotImplementedError('input must be a square matrix')
+    if m.chunks[0][0] != m.chunks[1][0]:
+        msg = ('chunks must be a square. '
+               'Use .rechunk method to change the size of chunks.')
+        raise NotImplementedError(msg)
+
+    rdim = len(m.chunks[0])
+    hdim = len(m.chunks[1])
+    chunk = m.chunks[0][0]
+
+    token = tokenize(m, k)
+    name = 'triu-' + token
+
+    dsk = {}
+    for i in range(rdim):
+        for j in range(hdim):
+            if chunk * (j - i + 1) < k:
+                dsk[(name, i, j)] = (np.zeros, (m.chunks[0][i], m.chunks[1][j]))
+            elif chunk * (j - i - 1) < k <= chunk * (j - i + 1):
+                dsk[(name, i, j)] = (np.triu, (m.name, i, j), k - (chunk * (j - i)))
+            else:
+                dsk[(name, i, j)] = (m.name, i, j)
+    dsk.update(m.dask)
+    return Array(dsk, name, shape=m.shape, chunks=m.chunks)
+
+
+def tril(m, k=0):
+    """
+    Lower triangle of an array with elements above the `k`-th diagonal zeroed.
+
+    Parameters
+    ----------
+    m : array_like, shape (M, M)
+        Input array.
+    k : int, optional
+        Diagonal above which to zero elements.  `k = 0` (the default) is the
+        main diagonal, `k < 0` is below it and `k > 0` is above.
+
+    Returns
+    -------
+    tril : ndarray, shape (M, M)
+        Lower triangle of `m`, of same shape and data-type as `m`.
+
+    See Also
+    --------
+    triu : upper triangle of an array
+    """
+    if m.ndim != 2:
+        raise ValueError('input must be 2 dimensional')
+    if m.shape[0] != m.shape[1]:
+        raise NotImplementedError('input must be a square matrix')
+    if not len(set(m.chunks[0] + m.chunks[1])) == 1:
+        msg = ('All chunks must be a square matrix to perform lu decomposition. '
+               'Use .rechunk method to change the size of chunks.')
+        raise ValueError(msg)
+
+    rdim = len(m.chunks[0])
+    hdim = len(m.chunks[1])
+    chunk = m.chunks[0][0]
+
+    token = tokenize(m, k)
+    name = 'tril-' + token
+
+    dsk = {}
+    for i in range(rdim):
+        for j in range(hdim):
+            if chunk * (j - i + 1) < k:
+                dsk[(name, i, j)] = (m.name, i, j)
+            elif chunk * (j - i - 1) < k <= chunk * (j - i + 1):
+                dsk[(name, i, j)] = (np.tril, (m.name, i, j), k - (chunk * (j - i)))
+            else:
+                dsk[(name, i, j)] = (np.zeros, (m.chunks[0][i], m.chunks[1][j]))
+    dsk.update(m.dask)
+    return Array(dsk, name, shape=m.shape, chunks=m.chunks)
+
+
 def chunks_from_arrays(arrays):
     """ Chunks tuple from nested list of arrays
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1801,3 +1801,27 @@ def test_cumulative():
     for axis in [0, 1, 2]:
         eq(x.cumsum(axis=axis), a.cumsum(axis=axis))
         eq(x.cumprod(axis=axis), a.cumprod(axis=axis))
+
+
+def test_tril_triu():
+    A = np.random.randn(20, 20)
+    for chunk in [5, 4]:
+        dA = da.from_array(A, (chunk, chunk))
+
+        assert np.allclose(da.triu(dA).compute(), np.triu(A))
+        assert np.allclose(da.tril(dA).compute(), np.tril(A))
+
+        for k in [-25, -20, -19, -15, -14, -9, -8, -6, -5, -1,
+                  1, 4, 5, 6, 8, 10, 11, 15, 16, 19, 20, 21]:
+            assert np.allclose(da.triu(dA, k).compute(), np.triu(A, k))
+            assert np.allclose(da.tril(dA, k).compute(), np.tril(A, k))
+
+def test_tril_triu_errors():
+    A = np.random.random_integers(0, 10, (10, 10, 10))
+    dA = da.from_array(A, chunks=(5, 5, 5))
+    assert raises(ValueError, lambda: da.triu(dA))
+
+    A = np.random.random_integers(0, 10, (30, 35))
+    dA = da.from_array(A, chunks=(5, 5))
+    assert raises(NotImplementedError, lambda: da.triu(dA))
+


### PR DESCRIPTION
Added ``da.triu`` and ``da.tril``. As a first impl, input must be a square matrix with equal horizontal / vertical chunks (can have remainder).

```
import numpy as np
import dask.array as da

A = np.random.random_integers(0, 10, (6, 6))
dA = da.from_array(A, (2, 2))

da.triu(dA).compute()
# array([[9, 1, 4, 5, 9, 6],
#        [0, 6, 2, 6, 5, 7],
#        [0, 0, 5, 3, 5, 5],
#        [0, 0, 0, 4, 3, 8],
#        [0, 0, 0, 0, 9, 3],
#        [0, 0, 0, 0, 0, 6]])

da.triu(dA, 3).compute()
# array([[ 0.,  0.,  0.,  5.,  9.,  6.],
#        [ 0.,  0.,  0.,  0.,  5.,  7.],
#        [ 0.,  0.,  0.,  0.,  0.,  5.],
#        [ 0.,  0.,  0.,  0.,  0.,  0.],
#        [ 0.,  0.,  0.,  0.,  0.,  0.],
#        [ 0.,  0.,  0.,  0.,  0.,  0.]])
```