### PR TITLE
ENH: Add linalg.solve_triangular

### DIFF
--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -239,16 +239,16 @@ def test_solve_triangular_vector():
         dAu = da.from_array(Au, (chunk, chunk))
         db = da.from_array(b, chunk)
         res = da.linalg.solve_triangular(dAu, db)
-        assert np.allclose(res.compute(), scipy.linalg.solve_triangular(Au, b))
-        assert np.allclose(dAu.dot(res).compute(), b)
+        assert_eq(res, scipy.linalg.solve_triangular(Au, b))
+        assert_eq(dAu.dot(res), b.astype(float))
 
         # lower
         Al = np.tril(A)
         dAl = da.from_array(Al, (chunk, chunk))
         db = da.from_array(b, chunk)
         res = da.linalg.solve_triangular(dAl, db, lower=True)
-        assert np.allclose(res.compute(), scipy.linalg.solve_triangular(Al, b, lower=True))
-        assert np.allclose(dAl.dot(res).compute(), b)
+        assert_eq(res, scipy.linalg.solve_triangular(Al, b, lower=True))
+        assert_eq(dAl.dot(res), b.astype(float))
 
 
 def test_solve_triangular_matrix():
@@ -265,16 +265,16 @@ def test_solve_triangular_matrix():
         dAu = da.from_array(Au, (chunk, chunk))
         db = da.from_array(b, (chunk, 5))
         res = da.linalg.solve_triangular(dAu, db)
-        assert np.allclose(res.compute(), scipy.linalg.solve_triangular(Au, b))
-        assert np.allclose(dAu.dot(res).compute(), b)
+        assert_eq(res, scipy.linalg.solve_triangular(Au, b))
+        assert_eq(dAu.dot(res), b.astype(float))
 
         # lower
         Al = np.tril(A)
         dAl = da.from_array(Al, (chunk, chunk))
         db = da.from_array(b, (chunk, 5))
         res = da.linalg.solve_triangular(dAl, db, lower=True)
-        assert np.allclose(res.compute(), scipy.linalg.solve_triangular(Al, b, lower=True))
-        assert np.allclose(dAl.dot(res).compute(), b)
+        assert_eq(res, scipy.linalg.solve_triangular(Al, b, lower=True))
+        assert_eq(dAl.dot(res), b.astype(float))
 
 
 
@@ -292,16 +292,16 @@ def test_solve_triangular_matrix2():
         dAu = da.from_array(Au, (chunk, chunk))
         db = da.from_array(b, (chunk, chunk))
         res = da.linalg.solve_triangular(dAu, db)
-        assert np.allclose(res.compute(), scipy.linalg.solve_triangular(Au, b))
-        assert np.allclose(dAu.dot(res).compute(), b)
+        assert_eq(res, scipy.linalg.solve_triangular(Au, b))
+        assert_eq(dAu.dot(res), b.astype(float))
 
         # lower
         Al = np.tril(A)
         dAl = da.from_array(Al, (chunk, chunk))
         db = da.from_array(b, (chunk, chunk))
         res = da.linalg.solve_triangular(dAl, db, lower=True)
-        assert np.allclose(res.compute(), scipy.linalg.solve_triangular(Al, b, lower=True))
-        assert np.allclose(dAl.dot(res).compute(), b)
+        assert_eq(res, scipy.linalg.solve_triangular(Al, b, lower=True))
+        assert_eq(dAl.dot(res), b.astype(float))
 
 
 def test_solve_triangular_errors():

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -1,3 +1,5 @@
+import difflib
+import os
 import numpy as np
 
 from .core import Array
@@ -15,7 +17,10 @@ def assert_eq(a, b, **kwargs):
     else:
         bdt = getattr(b, 'dtype', None)
 
-    assert str(adt) == str(bdt)
+    if str(adt) != str(bdt):
+        diff = difflib.ndiff(str(adt).splitlines(), str(bdt).splitlines())
+        raise AssertionError('string repr are different' + os.linesep +
+                             os.linesep.join(diff))
 
     try:
         assert np.allclose(a, b, **kwargs)


### PR DESCRIPTION
Added ``solve_triangular``, going to use with #885 to implement ``solve`` and ``inv``.

```
import numpy as np
import dask.array as da

np.random.seed(1)
A = np.random.random_integers(1, 10, (12, 12))
b = np.random.random_integers(1, 10, 12)
A = np.tril(A)

dA = da.from_array(A, (3, 3))
db = da.from_array(b, 3)

res = da.linalg.solve_triangular(dA, db, lower=True)
res.compute()
# array([   1.33333333,    0.33333333,   -0.83333333,   -0.76190476,
#          15.95238095,  -25.97142857,   -6.11428571,   43.34444444,
#         -18.42638889,  -17.75753968,  -12.45119048,  139.27301587])

np.allclose(dA.dot(res), b)
# True
```