### PR TITLE
Add categorical accessor to dd.Series

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -894,11 +894,11 @@ class Series(_Frame):
         return self.head().dtype
 
     def __getattr__(self, key):
-        head = self.head()
-        if key == 'cat' and isinstance(head.dtype, pd.core.dtypes.CategoricalDtype):
-            return head.cat
-        else:
-            raise AttributeError("'Series' object has no attribute %r" % key)
+        if key == 'cat':
+            head = self.head()
+            if isinstance(head.dtype, pd.core.dtypes.CategoricalDtype):
+                return head.cat
+        raise AttributeError("'Series' object has no attribute %r" % key)
 
     @property
     def column_info(self):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1285,12 +1285,9 @@ class DataFrame(_Frame):
 
     def __getattr__(self, key):
         try:
-            return object.__getattribute__(self, key)
-        except AttributeError as e:
-            try:
-                return self[key]
-            except KeyError as e:
-                raise AttributeError(e)
+            return self[key]
+        except KeyError as e:
+            raise AttributeError(e)
 
     def __dir__(self):
         return sorted(set(dir(type(self)) + list(self.__dict__) +
@@ -1966,12 +1963,9 @@ class GroupBy(_GroupBy):
 
     def __getattr__(self, key):
         try:
-            return object.__getattribute__(self, key)
-        except AttributeError:
-            try:
-                return self[key]
-            except KeyError:
-                raise AttributeError()
+            return self[key]
+        except KeyError as e:
+            raise AttributeError(e)
 
 
 class SeriesGroupBy(_GroupBy):
@@ -2564,16 +2558,14 @@ class Accessor(object):
                       dir(self.ns)))
 
     def __getattr__(self, key):
-        try:
-            return object.__getattribute__(self, key)
-        except AttributeError:
-            if key in dir(self.ns):
-                if isinstance(getattr(self.ns, key), property):
-                    return self._property_map(key)
-                else:
-                    return partial(self._function_map, key)
+        if key in dir(self.ns):
+            if isinstance(getattr(self.ns, key), property):
+                return self._property_map(key)
             else:
-                raise
+                return partial(self._function_map, key)
+        else:
+            raise AttributeError(key)
+
 
 class DatetimeAccessor(Accessor):
     """ Accessor object for datetimelike properties of the Series values.

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -893,6 +893,13 @@ class Series(_Frame):
         """ Return data type """
         return self.head().dtype
 
+    def __getattr__(self, key):
+        head = self.head()
+        if key == 'cat' and isinstance(head.dtype, pd.core.dtypes.CategoricalDtype):
+            return head.cat
+        else:
+            raise AttributeError("'Series' object has no attribute %r" % key)
+
     @property
     def column_info(self):
         """ Return Series.name """

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2511,3 +2511,12 @@ def test_to_imperative():
     assert isinstance(b, Value)
 
     assert eq(a.compute(), df.iloc[:2])
+
+
+def test_dataframe_categoricals():
+    df = pd.DataFrame({'x': list('a'*5 + 'b'*5 + 'c'*5),
+                       'y': range(15)})
+    df.x = df.x.astype('category')
+    ddf = dd.from_pandas(df, npartitions=2)
+    assert (df.x.cat.categories == pd.Index(['a', 'b', 'c'])).all()
+    assert not hasattr(df.y, 'cat')


### PR DESCRIPTION
This adds the categorical accessor (`Series.cat`) if the series is a categorical. This allows `dask.DataFrame`s to be used with `odo.discover` if they have a categorical dtype.

Caveat: Only pulls the categoricals from `Series.head()`. This means that only the categoricals for the first partition are used. However, if the categoricals aren't uniform across all partitions then calling `compute` on the series will fail anyway, as they can't be concatenated.

I also removed some unneeded calls to `object.__getattribute__` in a few implementations of `__getattr__`.