### PR TITLE
Fixes lu/tri array dtypes

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2717,7 +2717,7 @@ def triu(m, k=0):
             else:
                 dsk[(name, i, j)] = (m.name, i, j)
     dsk.update(m.dask)
-    return Array(dsk, name, shape=m.shape, chunks=m.chunks)
+    return Array(dsk, name, shape=m.shape, chunks=m.chunks, dtype=m.dtype)
 
 
 def tril(m, k=0):
@@ -2767,7 +2767,7 @@ def tril(m, k=0):
             else:
                 dsk[(name, i, j)] = (np.zeros, (m.chunks[0][i], m.chunks[1][j]))
     dsk.update(m.dask)
-    return Array(dsk, name, shape=m.shape, chunks=m.chunks)
+    return Array(dsk, name, shape=m.shape, chunks=m.chunks, dtype=m.dtype)
 
 
 def chunks_from_arrays(arrays):

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -442,8 +442,8 @@ def lu(a):
                 # l_permuted is not referred in lower triangulars
 
     dsk.update(a.dask)
-    p = Array(dsk, name_p, shape=a.shape, chunks=a.chunks, dtype=a.dtype)
-    l = Array(dsk, name_l, shape=a.shape, chunks=a.chunks, dtype=a.dtype)
-    u = Array(dsk, name_u, shape=a.shape, chunks=a.chunks, dtype=a.dtype)
+    p = Array(dsk, name_p, shape=a.shape, chunks=a.chunks)
+    l = Array(dsk, name_l, shape=a.shape, chunks=a.chunks)
+    u = Array(dsk, name_u, shape=a.shape, chunks=a.chunks)
 
     return p, l, u


### PR DESCRIPTION
Dtype fixes for my recent PRs.

- #885 ``lu`` should reset ``dtype``
- #926 ``triu`` and ``tril`` should hold ``dtype``
