### PR TITLE
ENH: Add da.eye

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -13,7 +13,7 @@ from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         fmax, fmin, isreal, iscomplex, isfinite, isinf, isnan, signbit,
         copysign, nextafter, ldexp, fmod, floor, ceil, trunc, degrees, radians,
         rint, fix, angle, real, imag, clip, fabs, sign, frexp, modf, around,
-        isnull, notnull, isclose, triu, tril)
+        isnull, notnull, isclose, eye, triu, tril)
 from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          moment,
                          argmin, argmax,

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1776,6 +1776,24 @@ def test_cumulative():
         assert_eq(x.cumprod(axis=axis), a.cumprod(axis=axis))
 
 
+def test_eye():
+    assert_eq(da.eye(9, chunks=3), np.eye(9))
+    assert_eq(da.eye(10, chunks=3), np.eye(10))
+    assert_eq(da.eye(9, chunks=3, M=11), np.eye(9, M=11))
+    assert_eq(da.eye(11, chunks=3, M=9), np.eye(11, M=9))
+    assert_eq(da.eye(7, chunks=3, M=11), np.eye(7, M=11))
+    assert_eq(da.eye(11, chunks=3, M=7), np.eye(11, M=7))
+    assert_eq(da.eye(9, chunks=3, k=2), np.eye(9, k=2))
+    assert_eq(da.eye(9, chunks=3, k=-2), np.eye(9, k=-2))
+    assert_eq(da.eye(7, chunks=3, M=11, k=5), np.eye(7, M=11, k=5))
+    assert_eq(da.eye(11, chunks=3, M=7, k=-6), np.eye(11, M=7, k=-6))
+    assert_eq(da.eye(6, chunks=3, M=9, k=7), np.eye(6, M=9, k=7))
+    assert_eq(da.eye(12, chunks=3, M=6, k=-3), np.eye(12, M=6, k=-3))
+
+    assert_eq(da.eye(9, chunks=3, dtype=int), np.eye(9, dtype=int))
+    assert_eq(da.eye(10, chunks=3, dtype=int), np.eye(10, dtype=int))
+
+
 def test_tril_triu():
     A = np.random.randn(20, 20)
     for chunk in [5, 4]:


### PR DESCRIPTION
Returns unit matrix or its shift, compat with ``np.eye``. 

```
da.eye(6, chunks=3).compute()
# array([[ 1.,  0.,  0.,  0.,  0.,  0.],
#        [ 0.,  1.,  0.,  0.,  0.,  0.],
#        [ 0.,  0.,  1.,  0.,  0.,  0.],
#        [ 0.,  0.,  0.,  1.,  0.,  0.],
#        [ 0.,  0.,  0.,  0.,  1.,  0.],
#        [ 0.,  0.,  0.,  0.,  0.,  1.]])

da.eye(6, chunks=3, M=5, k=2).compute()
# array([[ 0.,  0.,  1.,  0.,  0.],
#        [ 0.,  0.,  0.,  1.,  0.],
#        [ 0.,  0.,  0.,  0.,  1.],
#        [ 0.,  0.,  0.,  0.,  0.],
#        [ 0.,  0.,  0.,  0.,  0.],
#        [ 0.,  0.,  0.,  0.,  0.]])
```