### PR TITLE
ENH: add da.linalg.solve

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -553,3 +553,27 @@ def solve_triangular(a, b, lower=False):
     res = _solve_triangular_lower(np.array([[1, 0], [1, 2]], dtype=a.dtype),
                                   np.array([0, 1], dtype=b.dtype))
     return Array(dsk, name, shape=b.shape, chunks=b.chunks, dtype=res.dtype)
+
+
+def solve(a, b):
+    """
+    Solve the equation ``a x = b`` for ``x`` with LU decomposition and
+    forward / backward substitutions.
+
+    Parameters
+    ----------
+    a : (M, M) array_like
+        A square matrix.
+    b : (M,) or (M, N) array_like
+        Right-hand side matrix in ``a x = b``.
+
+    Returns
+    -------
+    x : (M,) or (M, N) Array
+        Solution to the system ``a x = b``.  Shape of the return matches the
+        shape of `b`.
+    """
+    p, l, u = lu(a)
+    uy = solve_triangular(l, p.T.dot(b), lower=True)
+    return solve_triangular(u, uy)
+

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -277,7 +277,6 @@ def test_solve_triangular_matrix():
         assert_eq(dAl.dot(res), b.astype(float))
 
 
-
 def test_solve_triangular_matrix2():
     import scipy.linalg
 
@@ -317,4 +316,37 @@ def test_solve_triangular_errors():
     db = da.from_array(b, chunks=5)
     assert raises(ValueError, lambda: da.linalg.solve_triangular(dA, db))
 
+
+def test_solve():
+    import scipy.linalg
+
+    for shape, chunk in [(20, 10), (50, 10)]:
+        np.random.seed(1)
+
+        A = np.random.random_integers(1, 10, (shape, shape))
+        dA = da.from_array(A, (chunk, chunk))
+
+        # vector
+        b = np.random.random_integers(1, 10, shape)
+        db = da.from_array(b, (chunk, chunk))
+
+        res = da.linalg.solve(dA, db)
+        assert_eq(res, scipy.linalg.solve(A, b))
+        assert_eq(dA.dot(res), b.astype(float))
+
+        # tall-and-skinny matrix
+        b = np.random.random_integers(1, 10, (shape, 5))
+        db = da.from_array(b, (chunk, 5))
+
+        res = da.linalg.solve(dA, db)
+        assert_eq(res, scipy.linalg.solve(A, b))
+        assert_eq(dA.dot(res), b.astype(float))
+
+        # matrix
+        b = np.random.random_integers(1, 10, (shape, shape))
+        db = da.from_array(b, (chunk, chunk))
+
+        res = da.linalg.solve(dA, db)
+        assert_eq(res, scipy.linalg.solve(A, b))
+        assert_eq(dA.dot(res), b.astype(float))
 


### PR DESCRIPTION
Added ``linalg.solve`` internally uses ``lu`` and ``solve_triangular``.

```
A = np.random.random_integers(0, 10, (9, 9))
b = np.random.random_integers(0, 10, 9)
dA = da.from_array(A, (3, 3))
db = da.from_array(b, 3)

res = da.linalg.solve(dA, db)
res.compute()
# array([ 10.08383006,   0.49277189,   4.08161013,  -1.37293649,
#         -5.85127562,   0.27764658,   1.51478334,  -5.09866267,  -3.60270823])

np.allclose(res.compute(), scipy.linalg.solve(A, b))
# True
```