### PR TITLE
ENH: add da.linalg.inv

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ..base import tokenize
 from ..compatibility import reduce
-from .core import top, dotmany, Array
+from .core import top, dotmany, Array, eye
 from .random import RandomState
 
 
@@ -576,4 +576,22 @@ def solve(a, b):
     p, l, u = lu(a)
     uy = solve_triangular(l, p.T.dot(b), lower=True)
     return solve_triangular(u, uy)
+
+
+def inv(a):
+    """
+    Compute the inverse of a matrix with LU decomposition and
+    forward / backward substitutions.
+
+    Parameters
+    ----------
+    a : array_like
+        Square matrix to be inverted.
+
+    Returns
+    -------
+    ainv : Array
+        Inverse of the matrix `a`.
+    """
+    return solve(a, eye(a.shape[0], chunks=a.chunks[0][0]))
 

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -350,3 +350,17 @@ def test_solve():
         assert_eq(res, scipy.linalg.solve(A, b))
         assert_eq(dA.dot(res), b.astype(float))
 
+
+def test_inv():
+    import scipy.linalg
+
+    for shape, chunk in [(20, 10), (50, 10)]:
+        np.random.seed(1)
+
+        A = np.random.random_integers(1, 10, (shape, shape))
+        dA = da.from_array(A, (chunk, chunk))
+
+        res = da.linalg.inv(dA)
+        assert_eq(res, scipy.linalg.inv(A))
+        assert_eq(dA.dot(res), np.eye(shape, dtype=float))
+


### PR DESCRIPTION
Should be after #938.

```
np.set_printoptions(precision=2)

A = np.random.random_integers(0, 10, (6, 6))
dA = da.from_array(A, (2, 2))
res = da.linalg.inv(dA)
res.compute()
# array([[ 0.12, -0.01,  0.16, -0.15,  0.07, -0.04],
#        [ 0.1 , -0.18, -0.23,  0.32, -0.16,  0.05],
#        [-0.01,  0.  ,  0.13,  0.03, -0.02, -0.18],
#        [-0.06,  0.03,  0.14, -0.07, -0.07,  0.08],
#        [-0.07,  0.14,  0.15, -0.28,  0.28, -0.01],
#        [ 0.06,  0.09, -0.29,  0.07,  0.02,  0.13]])

np.allclose(res.compute(), np.linalg.inv(A))
# True
```