### PR TITLE
Speedup for dd.from_dask_array

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -532,7 +532,8 @@ def from_dask_array(x, columns=None):
     for c in x.chunks[0]:
         divisions.append(divisions[-1] + c)
 
-    index = [(range, a, b) for a, b in zip(divisions[:-1], divisions[1:])]
+    index = [(np.arange, a, b, 1, 'i8') for a, b in
+             zip(divisions[:-1], divisions[1:])]
 
     divisions[-1] -= 1
 


### PR DESCRIPTION
Previously `range` (or `xrange` for python 2) was used to generate the index. Now `np.arange` is used instead. This results in a 40x speedup on my particular problem (for this part), and also releases the
GIL for this step.