### PR TITLE
ENH: Add Series.unique

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1059,6 +1059,19 @@ class Series(_Frame):
     def cummin(self, axis=None, skipna=True):
         return super(Series, self).cummin(axis=axis, skipna=skipna)
 
+    def unique(self):
+        """
+        Return Series of unique values in the object. Includes NA values.
+
+        Returns
+        -------
+        uniques : Series
+        """
+        # unique returns np.ndarray, it must be wrapped
+        chunk = lambda x: pd.Series(pd.Series.unique(x), name=self.name)
+        return aca(self, chunk=chunk, aggregate=chunk,
+                   columns=self.name, token='unique')
+
     @derived_from(pd.Series)
     def nunique(self):
         return self.drop_duplicates().count()

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -449,6 +449,14 @@ def test_value_counts():
     # https://github.com/pydata/pandas/pull/10419
     assert eq(result, expected, check_names=False)
 
+def test_unique():
+    pdf = pd.DataFrame({'x': [1, 2, 1, 3, 3, 1, 4, 2, 3, 1],
+                        'y': ['a', 'c', 'b', np.nan, 'c',
+                              'b', 'a', 'd', np.nan, 'a']})
+    ddf = dd.from_pandas(pdf, npartitions=3)
+    assert eq(ddf.x.unique(), pd.Series(pdf.x.unique(), name='x'))
+    assert eq(ddf.y.unique(), pd.Series(pdf.y.unique(), name='y'))
+
 
 def test_isin():
     assert eq(d.a.isin([0, 1, 2]), full.a.isin([0, 1, 2]))


### PR DESCRIPTION
Added ``Series.unique`` to return its unique values. Though ``pandas`` returns the result as ``np.ndarray``, ``dask`` return as ``Series``.

```
import dask.dataframe as dd
s = pd.Series([1, np.nan, 3, 2, 3, 4, np.nan])
ds = dd.from_pandas(s, 2)

# pandas
s.unique()
# array([  1.,  nan,   3.,   2.,   4.])

# dask
ds.unique().compute()
# 0    1.0
# 1    NaN
# 2    3.0
# 3    2.0
# 4    4.0
# dtype: float64
```